### PR TITLE
enable rollback as per detected system type

### DIFF
--- a/src/lib/handler.rs
+++ b/src/lib/handler.rs
@@ -1,8 +1,38 @@
 use anyhow::{Context, Result, anyhow, bail};
+use std::path::Path;
 use std::process::Command;
 use std::str;
 
 use crate::grub::get_boot_counter;
+
+/// Detects if the system is managed by bootc or is a rpm-ostree system
+fn detect_os_deployment() -> Option<&'static str> {
+    // 1. Check if this is a bootc-managed host.
+    if let Ok(output) = Command::new("bootc")
+        .args(["status", "--booted", "--json"])
+        .output()
+    {
+        if output.status.success() {
+            let stdout_str = String::from_utf8_lossy(&output.stdout);
+            // Check for the key-value pair as a substring. This is less robust
+            // than proper JSON parsing but avoids the external dependency.
+            if stdout_str.contains(r#""type": "bootcHost""#) {
+                log::info!("System detected as bootc-managed host.");
+                return Some("bootc");
+            }
+        }
+    }
+
+    // 2. If not bootc, check if it's an ostree-based OS by looking for /run/ostree-booted.
+    if Path::new("/run/ostree-booted").exists() {
+        log::info!("System detected as ostree-based (via /run/ostree-booted).");
+        return Some("rpm-ostree");
+    }
+
+    // 3. If neither check passes, the deployment type is unsupported.
+    log::warn!("System is neither bootc nor a known ostree variant.");
+    None
+}
 
 /// reboots the system if boot_counter is greater than 0 or can be forced too
 pub fn handle_reboot(force: bool) -> Result<()> {
@@ -17,7 +47,7 @@ pub fn handle_reboot(force: bool) -> Result<()> {
     Ok(())
 }
 
-/// rollback to previous deployment if boot counter is less than 0
+/// Rollback to the previous deployment if the boot counter allows.
 pub fn handle_rollback() -> Result<()> {
     let boot_counter = get_boot_counter("/boot/grub2/grubenv")?;
 
@@ -28,17 +58,30 @@ pub fn handle_rollback() -> Result<()> {
         }
         // Proceed with rollback if boot_counter is <= 0
         Some(counter) if counter <= 0 => {
-            log::info!("Greenboot will now attempt to rollback to previous deployment");
-            let status = Command::new("bootc")
-                .arg("rollback")
-                .status()
-                .context("Failed to execute bootc rollback")?;
-            if !status.success() {
-                bail!("Rollback error: {}", status);
+            log::info!("Greenboot will now attempt to rollback to a previous deployment.");
+            if let Some(deployment_cmd) = detect_os_deployment() {
+                log::info!(
+                    "Deployment manager '{}' detected, attempting rollback.",
+                    deployment_cmd
+                );
+                let status = Command::new(deployment_cmd)
+                    .arg("rollback")
+                    .status()
+                    .context(format!("Failed to execute '{} rollback'", deployment_cmd))?;
+
+                if !status.success() {
+                    bail!(
+                        "Rollback with '{}' failed with status: {}",
+                        deployment_cmd,
+                        status
+                    );
+                }
+            } else {
+                bail!("Rollback only supported in bootc or rpm-ostree environment.");
             }
             Ok(())
         }
-        // Reject if boot_counter is > 0 with the actual value
+        // Reject if boot_counter is > 0
         Some(counter) => bail!("Rollback not initiated as boot_counter is {}", counter),
     }
 }


### PR DESCRIPTION
detects system type and usees the rollback verb accordingly

greenboot checks for bootcHost in  bootc status to determine if its a bootc system else checks for the /run/ostree-booted file to detrmine if its a rpm-ostree system. Throws error if its neither.