### PR TITLE
Update greenboot.conf example for skipping scripts

### DIFF
--- a/etc/greenboot/greenboot.conf
+++ b/etc/greenboot/greenboot.conf
@@ -8,8 +8,6 @@ GREENBOOT_MAX_BOOT_ATTEMPTS=3
 ### the script names with spaces.
 ### NOTE: Script names must be spelled EXACTLY. Typos will result in
 ### unwanted behavior.
-### DISABLED_HEALTHCHECKS=(
-### 	"01_repository_dns_check.sh" 
-### 	"02_watchdog.sh"
-### )
+### DISABLED_HEALTHCHECKS=("01_repository_dns_check.sh" "02_watchdog.sh")
+
 DISABLED_HEALTHCHECKS=()


### PR DESCRIPTION
Previously, the example shown wouldn't result in the scripts being skipped. This updated example shows the correct format for how the user should put inputs into `DISABLED_HEALTHCHECKS`.

Addresses issue #64 

This is previously a closed issue because I made a mistake with syncing my branch before merging the changes I made in my previous PR. I made a new branch for this change now, and it will not happen again. Sorry for any confusion.