### PR TITLE
ci: add comment /test in pr can trigger CI

### DIFF
--- a/.github/workflows/greenboot-ci.yaml
+++ b/.github/workflows/greenboot-ci.yaml
@@ -4,16 +4,34 @@ name: CI Test
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
 
 jobs:
   check-pull-request:
+    if: |
+      github.event_name == 'pull_request_target' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        endsWith(github.event.comment.body, '/test')
+      )
     runs-on: ubuntu-latest
     steps:
+      - name: Set PR author
+        id: set-author
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request_target" ]; then
+            echo "AUTHOR=${{ github.event.pull_request.user.login }}" >> $GITHUB_ENV
+          else
+            echo "AUTHOR=${{ github.event.issue.user.login }}" >> $GITHUB_ENV
+          fi
+
       - name: Query author repository permissions
         uses: octokit/request-action@v2.x
         id: user_permission
         with:
-          route: GET /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission
+          route: GET /repos/${{ github.repository }}/collaborators/${{ env.AUTHOR }}/permission
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -21,7 +39,7 @@ jobs:
         if: contains('admin write', fromJson(steps.user_permission.outputs.data).permission)
         id: check_user_perm
         run: |
-          echo "User '${{ github.event.sender.login }}' has permission '${{ fromJson(steps.user_permission.outputs.data).permission }}' allowed values: 'admin', 'write'"
+          echo "User '${{ env.AUTHOR }}' has permission '${{ fromJson(steps.user_permission.outputs.data).permission }}' allowed values: 'admin', 'write'"
           echo "allowed_user=true" >> $GITHUB_OUTPUT
 
       - name: Get information for pull request


### PR DESCRIPTION
Add a new trigger of CI:
Adding comment /test in pull request can trigger CI, it can be useful when user want to rerun CI for pull request.