### PR TITLE
Update src name to greenboot-rs for fedora-43 change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           check_filenames: true
           check_hidden: true
           ignore_words_file: .github/spellcheck-ignore
-          skip: "./docs/Gemfile.lock,./docs/_config.yml,./.github,./.git,./greenboot.spec,./dist"
+          skip: "./docs/Gemfile.lock,./docs/_config.yml,./.github,./.git,./greenboot-rs.spec,./dist"
 
   fmt:
     name: Cargo fmt

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,13 +1,13 @@
 # https://packit.dev/docs/configuration/
 
-specfile_path: greenboot.spec
+specfile_path: greenboot-rs.spec
 
 files_to_sync:
-    - greenboot.spec
+    - greenboot-rs.spec
     - .packit.yaml
 
-upstream_package_name: greenboot
-downstream_package_name: greenboot
+upstream_package_name: greenboot-rs
+downstream_package_name: greenboot-rs
 
 upstream_tag_template: v{version}
 copy_upstream_release_description: true
@@ -17,14 +17,14 @@ srpm_build_deps:
 
 actions:
   get-current-version:
-  - grep -oP '^Version:\s+\K\S+' greenboot.spec
+  - grep -oP '^Version:\s+\K\S+' greenboot-rs.spec
   create-archive:
   - "cargo vendor vendor"
-  - bash -c "git archive --prefix=greenboot-${PACKIT_PROJECT_VERSION}/ --format=tar HEAD > greenboot-${PACKIT_PROJECT_VERSION}.tar"
-  - bash -c "tar -xvf greenboot-${PACKIT_PROJECT_VERSION}.tar"
-  - bash -c "tar -czf greenboot-${PACKIT_PROJECT_VERSION}.tar.gz greenboot-${PACKIT_PROJECT_VERSION}"
-  - bash -c "rm -rf greenboot-${PACKIT_PROJECT_VERSION} greenboot-${PACKIT_PROJECT_VERSION}.tar vendor"
-  - bash -c "ls -1 ./greenboot-*.tar.gz"
+  - bash -c "git archive --prefix=greenboot-rs-${PACKIT_PROJECT_VERSION}/ --format=tar HEAD > greenboot-rs-${PACKIT_PROJECT_VERSION}.tar"
+  - bash -c "tar -xvf greenboot-rs-${PACKIT_PROJECT_VERSION}.tar"
+  - bash -c "tar -czf greenboot-rs-${PACKIT_PROJECT_VERSION}.tar.gz greenboot-rs-${PACKIT_PROJECT_VERSION}"
+  - bash -c "rm -rf greenboot-rs-${PACKIT_PROJECT_VERSION} greenboot-rs-${PACKIT_PROJECT_VERSION}.tar vendor"
+  - bash -c "ls -1 ./greenboot-rs-*.tar.gz"
 
 jobs:
 - job: copr_build

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ TARGETDIR ?= target
 SRCDIR ?= .
 COMMIT = $(shell (cd "$(SRCDIR)" && git rev-parse HEAD))
 
-RPM_SPECFILE=rpmbuild/SPECS/greenboot-$(COMMIT).spec
-RPM_TARBALL=rpmbuild/SOURCES/greenboot-$(COMMIT).tar.gz
+RPM_SPECFILE=rpmbuild/SPECS/greenboot-rs-$(COMMIT).spec
+RPM_TARBALL=rpmbuild/SOURCES/greenboot-rs-$(COMMIT).tar.gz
 
 ifeq ($(RELEASE),1)
 	PROFILE ?= release
@@ -19,11 +19,11 @@ all: build check
 
 $(RPM_SPECFILE):
 	mkdir -p $(CURDIR)/rpmbuild/SPECS
-	(echo "%global commit $(COMMIT)"; git show HEAD:greenboot.spec) > $(RPM_SPECFILE)
+	(echo "%global commit $(COMMIT)"; git show HEAD:greenboot-rs.spec) > $(RPM_SPECFILE)
 
 $(RPM_TARBALL):
 	mkdir -p $(CURDIR)/rpmbuild/SOURCES
-	git archive --prefix=greenboot-$(COMMIT)/ --format=tar.gz HEAD > $(RPM_TARBALL)
+	git archive --prefix=greenboot-rs-$(COMMIT)/ --format=tar.gz HEAD > $(RPM_TARBALL)
 
 .PHONY: build
 build:


### PR DESCRIPTION
Update source package name to greenboot-rs, with binaries remaining greenboot. Provides/Obsoletes/Conflicts added to deprecate the bash version. 

See: https://fedoraproject.org/wiki/Changes/Greenboot_RS_Change_Proposal