### PR TITLE
ci: add make integration-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 RELEASE ?= 0
 TARGETDIR ?= target
 SRCDIR ?= .
-COMMIT = $(shell (cd "$(SRCDIR)" && git rev-parse HEAD))
+VERSION = $(shell grep -oP '^Version:\s+\K\S+' greenboot-rs.spec)
+COMMIT = $(shell (cd "$(SRCDIR)" && git rev-parse --short HEAD))
+TIMESTAMP = $(shell date +%Y%m%d%H%M%S)
 
-RPM_SPECFILE=rpmbuild/SPECS/greenboot-$(COMMIT).spec
-RPM_TARBALL=rpmbuild/SOURCES/greenboot-$(COMMIT).tar.gz
+# Create unique filenames with version+commit for build isolation
+RPM_SPECFILE=rpmbuild/SPECS/greenboot-rs-$(VERSION)-$(COMMIT).spec
+RPM_TARBALL=rpmbuild/SOURCES/greenboot-rs-$(VERSION).tar.gz
 
 ifeq ($(RELEASE),1)
 	PROFILE ?= release
@@ -19,33 +22,89 @@ all: build check
 
 $(RPM_SPECFILE):
 	mkdir -p $(CURDIR)/rpmbuild/SPECS
-	(echo "%global commit $(COMMIT)"; git show HEAD:greenboot.spec) > $(RPM_SPECFILE)
+	# Copy spec file as-is, no modifications - let the existing release string be used
+	cp greenboot-rs.spec $(RPM_SPECFILE)
 
 $(RPM_TARBALL):
 	mkdir -p $(CURDIR)/rpmbuild/SOURCES
-	git archive --prefix=greenboot-$(COMMIT)/ --format=tar.gz HEAD > $(RPM_TARBALL)
+	# Create tarball with directory name matching spec file expectations: greenboot-rs-<version>/
+	git archive --prefix=greenboot-rs-$(VERSION)/ --format=tar.gz HEAD > $(RPM_TARBALL)
 
 .PHONY: build
 build:
 	cargo build "--target-dir=${TARGETDIR}" ${CARGO_ARGS}
 
-.PHONY: install
-install: build
-	install -D -t ${DESTDIR}/usr/libexec "${TARGETDIR}/${PROFILE}/greenboot"
-	install -D -m 644 -t ${DESTDIR}/usr/lib/systemd/system dist/systemd/system/*.service
-
 .PHONY: check
 check:
-	cargo test "--target-dir=${TARGETDIR}" -- --test-threads=1
+	cargo test "--target-dir=${TARGETDIR}" ${CARGO_ARGS}
+
+.PHONY: fmt
+fmt:
+	cargo fmt
 
 .PHONY: srpm
 srpm: $(RPM_SPECFILE) $(RPM_TARBALL)
-	rpmbuild -bs \
+	rpmbuild -bs $(RPM_SPECFILE) \
 		--define "_topdir $(CURDIR)/rpmbuild" \
-		$(RPM_SPECFILE)
+		--define "_sourcedir $(CURDIR)/rpmbuild/SOURCES" \
+		--define "_specdir $(CURDIR)/rpmbuild/SPECS" \
+		--define "_srcrpmdir $(CURDIR)/rpmbuild/SRPMS"
 
 .PHONY: rpm
 rpm: $(RPM_SPECFILE) $(RPM_TARBALL)
-	rpmbuild -bb \
+	rpmbuild -bb $(RPM_SPECFILE) \
 		--define "_topdir $(CURDIR)/rpmbuild" \
-		$(RPM_SPECFILE)
+		--define "_sourcedir $(CURDIR)/rpmbuild/SOURCES" \
+		--define "_specdir $(CURDIR)/rpmbuild/SPECS" \
+		--define "_builddir $(CURDIR)/rpmbuild/BUILD" \
+		--define "_rpmdir $(CURDIR)/rpmbuild/RPMS"
+
+.PHONY: clean
+clean:
+	cargo clean "--target-dir=${TARGETDIR}"
+	rm -rf rpmbuild
+
+# integration-test: Run the bootc image integration tests (requires QUAY credentials)
+#
+# Prerequisites:
+#   - Must be executed on Fedora Rawhide OR CentOS Stream 10
+#   - Requires QUAY_USERNAME and QUAY_PASSWORD environment variables
+#
+# Usage:
+#   QUAY_USERNAME=<your_quay_username> QUAY_PASSWORD=<your_quay_pass> make integration-test
+.PHONY: integration-test
+integration-test:
+	@# Verify required environment variables are set
+	@if [ -z "$$QUAY_USERNAME" ]; then \
+		echo "ERROR: QUAY_USERNAME environment variable not set"; \
+		echo "Usage: QUAY_USERNAME=quay_user QUAY_PASSWORD=quay_pass make integration-test"; \
+		exit 1; \
+	fi
+	@if [ -z "$$QUAY_PASSWORD" ]; then \
+		echo "ERROR: QUAY_PASSWORD environment variable not set"; \
+		echo "Usage: QUAY_USERNAME=quay_user QUAY_PASSWORD=quay_pass make integration-test"; \
+		exit 1; \
+	fi
+
+	@# Verify supported operating system
+	@. /etc/os-release; \
+	if [ "$$ID" = "fedora" ] && { [ "$$VERSION_ID" = "rawhide" ] || [ "$$VERSION_ID" = "43" ]; }; then \
+		echo "Running on Fedora $$VERSION_ID"; \
+	elif [ "$$ID" = "centos" ] && [ "$$VERSION_ID" = "10" ]; then \
+		echo "Running on CentOS Stream $$VERSION_ID"; \
+	else \
+		echo "Unsupported OS: $$ID $$VERSION_ID"; \
+		echo "This test requires Fedora Rawhide or CentOS Stream 10"; \
+		exit 1; \
+	fi
+
+	@# Run test script and report results
+	@echo "Starting integration test"; \
+	cd tests && ./greenboot-bootc-qcow2.sh; \
+	TEST_EXIT=$$?; \
+	if [ $$TEST_EXIT -eq 0 ]; then \
+		echo "SUCCESS: Integration test passed"; \
+	else \
+		echo "FAILURE: Integration test failed"; \
+		exit $$TEST_EXIT; \
+	fi

--- a/README.md
+++ b/README.md
@@ -89,3 +89,15 @@ At the moment, it is possible to customize the following parameters via environm
     - Unsets `boot_counter` GRUB env var and sets `boot_success` GRUB env var to 1.
     - Runs the scripts in `green.d` folder, scripts that are meant to be run after a successful update.
     - Creates the MOTD with a success message.
+
+## Integration Tests
+
+To run integration tests:
+
+1. **Requirements**:
+   - Fedora Rawhide OR CentOS Stream 10
+   - Quay.io account with container registry access
+
+2. **Execution**:
+   ```bash
+   QUAY_USERNAME=<your_quay_username> QUAY_PASSWORD=<your_quay_password> make integration-test

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -162,7 +162,6 @@ cp testing_assets/failing_binary tests/ && popd
 ###########################################################
 greenprint "Building bootc container with greenboot installed"
 podman login quay.io -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD}
-podman login registry.stage.redhat.io -u ${STAGE_REDHAT_IO_USERNAME} -p ${STAGE_REDHAT_IO_TOKEN}
 tee Containerfile > /dev/null << EOF
 FROM ${BASE_IMAGE_URL}
 # Copy the local RPM files into the container

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -162,7 +162,6 @@ cp testing_assets/failing_binary tests/ && popd
 ###########################################################
 greenprint "Building bootc container with greenboot installed"
 podman login quay.io -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD}
-podman login registry.stage.redhat.io -u ${STAGE_REDHAT_IO_USERNAME} -p ${STAGE_REDHAT_IO_TOKEN}
 tee Containerfile > /dev/null << EOF
 FROM ${BASE_IMAGE_URL}
 # Copy the local RPM files into the container


### PR DESCRIPTION
This PR will add a new rule to Makefile, user can run 'make integration-test' to trigger a local CI test.