### PR TITLE
Update rawhide in ci

### DIFF
--- a/.github/workflows/greenboot-ci.yaml
+++ b/.github/workflows/greenboot-ci.yaml
@@ -91,13 +91,36 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
-          compose: Fedora-Rawhide
+          compose: Fedora-43
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.check-pull-request.outputs.repo_url }}
           git_ref: ${{ needs.check-pull-request.outputs.ref }}
           update_pull_request_status: true
           pull_request_status_name: fedora-43-bootc
           tmt_context: "arch=x86_64;distro=fedora-43"
+          tmt_plan_regex: bootc
+          tf_scope: private
+          variables: "ARCH=x86_64"
+          timeout: 90
+          secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
+
+  fedora-44-bootc:
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run the tests
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
+        with:
+          compose: Fedora-Rawhide
+          api_key: ${{ secrets.TF_API_KEY }}
+          git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+          git_ref: ${{ needs.check-pull-request.outputs.ref }}
+          update_pull_request_status: true
+          pull_request_status_name: fedora-44-bootc
+          tmt_context: "arch=x86_64;distro=fedora-44"
           tmt_plan_regex: bootc
           tf_scope: private
           variables: "ARCH=x86_64"

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -38,7 +38,15 @@ case "${ID}-${VERSION_ID}" in
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"
         sudo dnf install -y rpmbuild rust-packaging
-        sudo dnf install -y rust-anyhow+default-devel rust-clap+derive-devel rust-clap+default-devel rust-clap_derive-devel rust-config+default-devel rust-config-devel rust-env_logger+default-devel rust-env_logger-devel rust-glob+default-devel rust-glob-devel rust-log+default-devel rust-log-devel rust-nix+default-devel rust-nix-devel rust-once_cell+default-devel rust-once_cell-devel rust-pretty_env_logger+default-devel rust-pretty_env_logger-devel rust-serde+default-devel rust-serde-devel rust-serde_json+default-devel rust-serde_json-devel rust-tempfile+default-devel rust-tempfile-devel rust-thiserror+default-devel rust-thiserror-devel
+        sudo dnf install -y rust-anyhow+default-devel rust-clap+derive-devel rust-clap+default-devel rust-clap_derive-devel rust-config+default-devel rust-config-devel rust-env_logger+default-devel rust-env_logger-devel rust-glob+default-devel rust-glob-devel rust-log+default-devel rust-log-devel rust-nix+default-devel rust-nix-devel rust-once_cell+default-devel rust-once_cell-devel rust-pretty_env_logger+default-devel rust-pretty_env_logger-devel rust-serde+default-devel rust-serde-devel rust-serde_json+default-devel rust-serde_json-devel rust-tempfile+default-devel rust-tempfile-devel rust-thiserror+default-devel rust-thiserror-devel pkgconf-pkg-config openssl-devel
+        ;;
+    "fedora-44")
+        OS_VARIANT="fedora-rawhide"
+        BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:44"
+        BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
+        BOOT_ARGS="uefi"
+        sudo dnf install -y rpmbuild rust-packaging
+        sudo dnf install -y rust-anyhow+default-devel rust-clap+derive-devel rust-clap+default-devel rust-clap_derive-devel rust-config+default-devel rust-config-devel rust-env_logger+default-devel rust-env_logger-devel rust-glob+default-devel rust-glob-devel rust-log+default-devel rust-log-devel rust-nix+default-devel rust-nix-devel rust-once_cell+default-devel rust-once_cell-devel rust-pretty_env_logger+default-devel rust-pretty_env_logger-devel rust-serde+default-devel rust-serde-devel rust-serde_json+default-devel rust-serde_json-devel rust-tempfile+default-devel rust-tempfile-devel rust-thiserror+default-devel rust-thiserror-devel pkgconf-pkg-config openssl-devel
         ;;
     "centos-10")
         OS_VARIANT="centos-stream9"

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -38,7 +38,15 @@ case "${ID}-${VERSION_ID}" in
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"
         sudo dnf install -y rpmbuild rust-packaging
-        sudo dnf install -y rust-anyhow+default-devel rust-clap+derive-devel rust-clap+default-devel rust-clap_derive-devel rust-config+default-devel rust-config-devel rust-env_logger+default-devel rust-env_logger-devel rust-glob+default-devel rust-glob-devel rust-log+default-devel rust-log-devel rust-nix+default-devel rust-nix-devel rust-once_cell+default-devel rust-once_cell-devel rust-pretty_env_logger+default-devel rust-pretty_env_logger-devel rust-serde+default-devel rust-serde-devel rust-serde_json+default-devel rust-serde_json-devel rust-tempfile+default-devel rust-tempfile-devel rust-thiserror+default-devel rust-thiserror-devel
+        sudo dnf install -y rust-anyhow+default-devel rust-clap+derive-devel rust-clap+default-devel rust-clap_derive-devel rust-config+default-devel rust-config-devel rust-env_logger+default-devel rust-env_logger-devel rust-glob+default-devel rust-glob-devel rust-log+default-devel rust-log-devel rust-nix+default-devel rust-nix-devel rust-once_cell+default-devel rust-once_cell-devel rust-pretty_env_logger+default-devel rust-pretty_env_logger-devel rust-serde+default-devel rust-serde-devel rust-serde_json+default-devel rust-serde_json-devel rust-tempfile+default-devel rust-tempfile-devel rust-thiserror+default-devel rust-thiserror-devel pkgconf-pkg-config openssl-devel
+        ;;
+    "fedora-44")
+        OS_VARIANT="fedora-rawhide"
+        BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:44"
+        BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
+        BOOT_ARGS="uefi"
+        sudo dnf install -y rpmbuild rust-packaging
+        sudo dnf install -y rust-anyhow+default-devel rust-clap+derive-devel rust-clap+default-devel rust-clap_derive-devel rust-config+default-devel rust-config-devel rust-env_logger+default-devel rust-env_logger-devel rust-glob+default-devel rust-glob-devel rust-log+default-devel rust-log-devel rust-nix+default-devel rust-nix-devel rust-once_cell+default-devel rust-once_cell-devel rust-pretty_env_logger+default-devel rust-pretty_env_logger-devel rust-serde+default-devel rust-serde-devel rust-serde_json+default-devel rust-serde_json-devel rust-tempfile+default-devel rust-tempfile-devel rust-thiserror+default-devel rust-thiserror-devel pkgconf-pkg-config openssl-devel
         ;;
     "centos-10")
         OS_VARIANT="centos-stream9"


### PR DESCRIPTION
Now that Fedora-43 has branched from the rolling Rawhide, we should update greenboot CI workflow jobs and test cases.