### PR TITLE
ci: include support to fedora-44

### DIFF
--- a/.github/workflows/greenboot-ci.yaml
+++ b/.github/workflows/greenboot-ci.yaml
@@ -91,13 +91,36 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
-          compose: Fedora-Rawhide
+          compose: Fedora-43
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.check-pull-request.outputs.repo_url }}
           git_ref: ${{ needs.check-pull-request.outputs.ref }}
           update_pull_request_status: true
           pull_request_status_name: fedora-43-bootc
           tmt_context: "arch=x86_64;distro=fedora-43"
+          tmt_plan_regex: bootc
+          tf_scope: private
+          variables: "ARCH=x86_64"
+          timeout: 90
+          secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
+
+  fedora-44-bootc:
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run the tests
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
+        with:
+          compose: Fedora-Rawhide
+          api_key: ${{ secrets.TF_API_KEY }}
+          git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+          git_ref: ${{ needs.check-pull-request.outputs.ref }}
+          update_pull_request_status: true
+          pull_request_status_name: fedora-44-bootc
+          tmt_context: "arch=x86_64;distro=fedora-44"
           tmt_plan_regex: bootc
           tf_scope: private
           variables: "ARCH=x86_64"

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ integration-test:
 
 	@# Verify supported operating system
 	@. /etc/os-release; \
-	if [ "$$ID" = "fedora" ] && { [ "$$VERSION_ID" = "rawhide" ] || [ "$$VERSION_ID" = "43" ]; }; then \
+	if [ "$$ID" = "fedora" ] && { [ "$$VERSION_ID" = "rawhide" ] || [ "$$VERSION_ID" = "43" ] || [ "$$VERSION_ID" = "44" ]; }; then \
 		echo "Running on Fedora $$VERSION_ID"; \
 	elif [ "$$ID" = "centos" ] && [ "$$VERSION_ID" = "10" ]; then \
 		echo "Running on CentOS Stream $$VERSION_ID"; \

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -39,6 +39,13 @@ case "${ID}-${VERSION_ID}" in
         BOOT_ARGS="uefi"
         sudo dnf install -y rpmbuild rust-packaging
         ;;
+    "fedora-44")
+        OS_VARIANT="fedora-rawhide"
+        BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:44"
+        BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
+        BOOT_ARGS="uefi"
+        sudo dnf install -y rpmbuild rust-packaging
+        ;;
     "centos-10")
         OS_VARIANT="centos-stream9"
         BASE_IMAGE_URL="quay.io/centos-bootc/centos-bootc:stream10"

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -39,6 +39,13 @@ case "${ID}-${VERSION_ID}" in
         BOOT_ARGS="uefi"
         sudo dnf install -y rpmbuild rust-packaging
         ;;
+    "fedora-44")
+        OS_VARIANT="fedora-rawhide"
+        BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:44"
+        BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
+        BOOT_ARGS="uefi"
+        sudo dnf install -y rpmbuild rust-packaging
+        ;;
     "centos-10")
         OS_VARIANT="centos-stream9"
         BASE_IMAGE_URL="quay.io/centos-bootc/centos-bootc:stream10"


### PR DESCRIPTION
This PR includes Fedora-44 Rawhide in our workflow jobs, and also updates bootc-anaconda-iso and bootc-qcow2 test cases.