### PR TITLE
ci: add gobject-introspection to fix virt-install runtime error

### DIFF
--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -89,7 +89,8 @@ wait_for_ssh_up () {
 ##
 ###########################################################
 greenprint "Installing required packages"
-sudo dnf install -y podman qemu-img firewalld qemu-kvm libvirt-client libvirt-daemon-kvm libvirt-daemon virt-install rpmdevtools ansible-core cargo lorax
+# gobject-introspection: workaround for virt-install dependency resolution in CI
+sudo dnf install -y podman qemu-img firewalld qemu-kvm libvirt-client libvirt-daemon-kvm libvirt-daemon virt-install rpmdevtools ansible-core cargo lorax gobject-introspection
 ansible-galaxy collection install community.general
 
 # Start firewalld

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -89,7 +89,8 @@ wait_for_ssh_up () {
 ##
 ###########################################################
 greenprint "Installing required packages"
-sudo dnf install -y podman qemu-img firewalld qemu-kvm libvirt-client libvirt-daemon-kvm libvirt-daemon virt-install rpmdevtools ansible-core cargo lorax
+# gobject-introspection: workaround for virt-install dependency resolution in CI
+sudo dnf install -y podman qemu-img firewalld qemu-kvm libvirt-client libvirt-daemon-kvm libvirt-daemon virt-install rpmdevtools ansible-core cargo lorax gobject-introspection
 ansible-galaxy collection install community.general
 
 # Start firewalld

--- a/tests/greenboot-ostree.sh
+++ b/tests/greenboot-ostree.sh
@@ -64,7 +64,8 @@ sudo localectl set-locale LANG=en_US.UTF-8
 
 # Install required packages
 greenprint "Install required packages"
-sudo dnf install -y --nogpgcheck httpd osbuild osbuild-composer composer-cli ansible-core createrepo_c podman qemu-img firewalld qemu-kvm libvirt-client libvirt-daemon-kvm libvirt-daemon virt-install rpmdevtools cargo lorax
+# gobject-introspection: workaround for virt-install dependency resolution in CI
+sudo dnf install -y --nogpgcheck httpd osbuild osbuild-composer composer-cli ansible-core createrepo_c podman qemu-img firewalld qemu-kvm libvirt-client libvirt-daemon-kvm libvirt-daemon virt-install rpmdevtools cargo lorax gobject-introspection
 
 # Avoid collection installation filed sometime
 for _ in $(seq 0 30); do


### PR DESCRIPTION
Fedora virt-install tests are failing with the error:
`gi.RepositoryError: Typelib file for namespace 'libxml2', version '2.0' not found`
    
This adds the missing dependency as a workaround.
