### PR TITLE
fix: create vendor tarball during propose_downstream

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -37,6 +37,12 @@ actions:
   - "sed -i '/^%forgeautosetup/d' greenboot-rs.spec"
   - bash -c "git config user.name 'Packit Build' || true"
   - bash -c "git config user.email 'packit@fedoraproject.org' || true"
+  post-modifications:
+  # This runs during propose_downstream to prepare the vendor tarball for upload
+  - bash -c "cargo vendor vendor"
+  - bash -c "tar -cJf greenboot-rs-${PACKIT_PROJECT_VERSION}-vendor-patched.tar.xz vendor"
+  - bash -c "rm -rf vendor"
+  - bash -c 'if [ -n "${PACKIT_DOWNSTREAM_REPO}" ]; then cp greenboot-rs-${PACKIT_PROJECT_VERSION}-vendor-patched.tar.xz ${PACKIT_DOWNSTREAM_REPO}/; fi'
   fix-spec-file:
   # This runs after Packit's release processing - disable debug package to prevent saypaul error
   - "sed -i '/^License:/a\\%global debug_package %{nil}' greenboot-rs.spec"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -36,6 +36,16 @@ actions:
   - "sed -i '/^License:/a\\%global debug_package %{nil}' greenboot-rs.spec"
   - bash -c "git config user.name 'Packit Build' || true"
   - bash -c "git config user.email 'packit@fedoraproject.org' || true"
+  post-modifications:
+  - |
+    bash -exc '
+    cargo vendor vendor
+    tar -cJf "greenboot-rs-${PACKIT_PROJECT_VERSION}-vendor-patched.tar.xz" vendor
+    rm -rf vendor
+    if [ -n "${PACKIT_DOWNSTREAM_REPO}" ]; then
+      cp "greenboot-rs-${PACKIT_PROJECT_VERSION}-vendor-patched.tar.xz" "${PACKIT_DOWNSTREAM_REPO}/"
+    fi
+    '
 
 jobs:
 - job: copr_build


### PR DESCRIPTION
Add post-modifications action to create the vendor tarball and copy it to
the downstream repository before Packit uploads to the lookaside cache.
This ensures both Source0 and Source1 are available during propose_downstream.
    
Follows the same pattern used by go-fdo-server and go-fdo-client.
