### PR TITLE
ci: add RHEL9.8/10.2 test coverage

### DIFF
--- a/.github/workflows/comment-ci.yaml
+++ b/.github/workflows/comment-ci.yaml
@@ -86,7 +86,7 @@ jobs:
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
-  fedora-44-bootc:
+  fedora-45-bootc:
     needs: check-pull-request
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
     continue-on-error: true
@@ -101,15 +101,39 @@ jobs:
           git_url: ${{ needs.check-pull-request.outputs.repo_url }}
           git_ref: ${{ needs.check-pull-request.outputs.ref }}
           update_pull_request_status: true
-          pull_request_status_name: fedora-44-bootc
-          tmt_context: "arch=x86_64;distro=fedora-44"
+          pull_request_status_name: fedora-45-bootc
+          tmt_context: "arch=x86_64;distro=fedora-45"
           tmt_plan_regex: bootc
           tf_scope: private
           variables: "ARCH=x86_64"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
-  centos-9-ostree:
+  # TODO: uncomment once fix https://github.com/osbuild/images/pull/2251 is landed in CS9
+  # centos-9-ostree:
+  #   needs: check-pull-request
+  #   if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+  #   continue-on-error: true
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Run the tests
+  #       uses: sclorg/testing-farm-as-github-action@v3.1.2
+  #       with:
+  #         compose: CentOS-Stream-9
+  #         api_key: ${{ secrets.TF_API_KEY }}
+  #         git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+  #         git_ref: ${{ needs.check-pull-request.outputs.ref }}
+  #         update_pull_request_status: true
+  #         pull_request_status_name: centos-9-ostree
+  #         tmt_context: "arch=x86_64;distro=cs-9"
+  #         tmt_plan_regex: ostree
+  #         tf_scope: private
+  #         variables: "ARCH=x86_64"
+  #         timeout: 90
+  #         secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
+
+  rhel-9-8-ostree:
     needs: check-pull-request
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
     continue-on-error: true
@@ -119,14 +143,37 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
-          compose: CentOS-Stream-9
+          compose: RHEL-9.8.0-Nightly
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.check-pull-request.outputs.repo_url }}
           git_ref: ${{ needs.check-pull-request.outputs.ref }}
           update_pull_request_status: true
-          pull_request_status_name: centos-9-ostree
-          tmt_context: "arch=x86_64;distro=cs-9"
+          pull_request_status_name: rhel-9-8-ostree
+          tmt_context: "arch=x86_64;distro=rhel-9-8"
           tmt_plan_regex: ostree
+          tf_scope: private
+          variables: "ARCH=x86_64"
+          timeout: 90
+          secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
+
+  rhel-10-2-bootc:
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run the tests
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
+        with:
+          compose: RHEL-10.2-Nightly
+          api_key: ${{ secrets.TF_API_KEY }}
+          git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+          git_ref: ${{ needs.check-pull-request.outputs.ref }}
+          update_pull_request_status: true
+          pull_request_status_name: rhel-10-2-bootc
+          tmt_context: "arch=x86_64;distro=rhel-10-2"
+          tmt_plan_regex: bootc
           tf_scope: private
           variables: "ARCH=x86_64"
           timeout: 90

--- a/.github/workflows/greenboot-ci.yaml
+++ b/.github/workflows/greenboot-ci.yaml
@@ -84,7 +84,7 @@ jobs:
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
-  fedora-44-bootc:
+  fedora-45-bootc:
     needs: check-pull-request
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
     continue-on-error: true
@@ -99,15 +99,39 @@ jobs:
           git_url: ${{ needs.check-pull-request.outputs.repo_url }}
           git_ref: ${{ needs.check-pull-request.outputs.ref }}
           update_pull_request_status: true
-          pull_request_status_name: fedora-44-bootc
-          tmt_context: "arch=x86_64;distro=fedora-44"
+          pull_request_status_name: fedora-45-bootc
+          tmt_context: "arch=x86_64;distro=fedora-45"
           tmt_plan_regex: bootc
           tf_scope: private
           variables: "ARCH=x86_64"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
-  centos-9-ostree:
+  # TODO: uncomment once fix https://github.com/osbuild/images/pull/2251 is landed in CS9
+  # centos-9-ostree:
+  #   needs: check-pull-request
+  #   if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+  #   continue-on-error: true
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Run the tests
+  #       uses: sclorg/testing-farm-as-github-action@v3.1.2
+  #       with:
+  #         compose: CentOS-Stream-9
+  #         api_key: ${{ secrets.TF_API_KEY }}
+  #         git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+  #         git_ref: ${{ needs.check-pull-request.outputs.ref }}
+  #         update_pull_request_status: true
+  #         pull_request_status_name: centos-9-ostree
+  #         tmt_context: "arch=x86_64;distro=cs-9"
+  #         tmt_plan_regex: ostree
+  #         tf_scope: private
+  #         variables: "ARCH=x86_64"
+  #         timeout: 90
+  #         secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
+
+  rhel-9-8-ostree:
     needs: check-pull-request
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
     continue-on-error: true
@@ -117,14 +141,37 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
-          compose: CentOS-Stream-9
+          compose: RHEL-9.8.0-Nightly
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.check-pull-request.outputs.repo_url }}
           git_ref: ${{ needs.check-pull-request.outputs.ref }}
           update_pull_request_status: true
-          pull_request_status_name: centos-9-ostree
-          tmt_context: "arch=x86_64;distro=cs-9"
+          pull_request_status_name: rhel-9-8-ostree
+          tmt_context: "arch=x86_64;distro=rhel-9-8"
           tmt_plan_regex: ostree
+          tf_scope: private
+          variables: "ARCH=x86_64"
+          timeout: 90
+          secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
+
+  rhel-10-2-bootc:
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run the tests
+        uses: sclorg/testing-farm-as-github-action@v3.1.2
+        with:
+          compose: RHEL-10.2-Nightly
+          api_key: ${{ secrets.TF_API_KEY }}
+          git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+          git_ref: ${{ needs.check-pull-request.outputs.ref }}
+          update_pull_request_status: true
+          pull_request_status_name: rhel-10-2-bootc
+          tmt_context: "arch=x86_64;distro=rhel-10-2"
+          tmt_plan_regex: bootc
           tf_scope: private
           variables: "ARCH=x86_64"
           timeout: 90

--- a/tests/files/rhel-10-2.repo
+++ b/tests/files/rhel-10-2.repo
@@ -1,0 +1,10 @@
+[RHEL-10.2-NIGHTLY-BaseOS]
+name=baseos
+baseurl=http://REPLACE_ME_HERE/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/BaseOS/x86_64/os
+enabled=1
+gpgcheck=0
+[RHEL-10.2-NIGHTLY-AppStream]
+name=appstream
+baseurl=http://REPLACE_ME_HERE/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/AppStream/x86_64/os/
+enabled=1
+gpgcheck=0

--- a/tests/files/rhel-9-8.repo
+++ b/tests/files/rhel-9-8.repo
@@ -1,0 +1,10 @@
+[RHEL-9.8-NIGHTLY-BaseOS]
+name=baseos
+baseurl=http://REPLACE_ME_HERE/rhel-9/nightly/RHEL-9/latest-RHEL-9.8.0/compose/BaseOS/x86_64/os/
+enabled=1
+gpgcheck=0
+[RHEL-9.8-NIGHTLY-AppStream]
+name=appstream
+baseurl=http://REPLACE_ME_HERE/rhel-9/nightly/RHEL-9/latest-RHEL-9.8.0/compose/AppStream/x86_64/os/
+enabled=1
+gpgcheck=0

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -40,8 +40,15 @@ case "${ID}-${VERSION_ID}" in
         sudo dnf install -y rpmbuild rust-packaging
         ;;
     "fedora-44")
-        OS_VARIANT="fedora-rawhide"
+        OS_VARIANT="fedora-44"
         BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:44"
+        BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
+        BOOT_ARGS="uefi"
+        sudo dnf install -y rpmbuild rust-packaging
+        ;;
+    "fedora-45")
+        OS_VARIANT="fedora-rawhide"
+        BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:rawhide"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"
         sudo dnf install -y rpmbuild rust-packaging
@@ -52,6 +59,22 @@ case "${ID}-${VERSION_ID}" in
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
         sudo dnf install -y make rpm-build rust-toolset
+        ;;
+    "rhel-9.8")
+        OS_VARIANT="rhel9-unknown"
+        BASE_IMAGE_URL="registry.stage.redhat.io/rhel9/rhel-bootc:9.8"
+        BIB_URL="registry.stage.redhat.io/rhel9/bootc-image-builder:9.8"
+        BOOT_ARGS="uefi"
+        sudo dnf install -y make rpm-build rust-toolset
+        sed -i "s/REPLACE_ME_HERE/${DOWNLOAD_NODE}/g" files/rhel-9-8.repo
+        ;;
+    "rhel-10.2")
+        OS_VARIANT="rhel10-unknown"
+        BASE_IMAGE_URL="registry.stage.redhat.io/rhel10/rhel-bootc:10.2"
+        BIB_URL="registry.stage.redhat.io/rhel10/bootc-image-builder:10.2"
+        BOOT_ARGS="uefi"
+        sudo dnf install -y make rpm-build rust-toolset
+        sed -i "s/REPLACE_ME_HERE/${DOWNLOAD_NODE}/g" files/rhel-10-2.repo
         ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
@@ -170,6 +193,7 @@ cp testing_assets/failing_binary tests/ && popd
 ###########################################################
 greenprint "Building bootc container with greenboot installed"
 podman login quay.io -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD}
+podman login registry.stage.redhat.io -u ${STAGE_REDHAT_IO_USERNAME} -p ${STAGE_REDHAT_IO_TOKEN}
 tee Containerfile > /dev/null << EOF
 FROM ${BASE_IMAGE_URL}
 # Copy the local RPM files into the container
@@ -195,6 +219,19 @@ COPY failing_binary /etc/greenboot/check/wanted.d/
 # Clean up by removing the local RPMs if desired
 RUN rm -f /tmp/greenboot-*.rpm
 EOF
+
+if [[ "${ID}-${VERSION_ID}" == "rhel-9.8" ]]; then
+    tee -a Containerfile >> /dev/null << EOF
+COPY files/rhel-9-8.repo /etc/yum.repos.d/rhel-9-8.repo
+EOF
+fi
+
+if [[ "${ID}-${VERSION_ID}" == "rhel-10.2" ]]; then
+    tee -a Containerfile >> /dev/null << EOF
+COPY files/rhel-10-2.repo /etc/yum.repos.d/rhel-10-2.repo
+EOF
+fi
+
 podman build  --retry=5 --retry-delay=10s -t quay.io/${QUAY_USERNAME}/greenboot-bootc:${TEST_UUID} -f Containerfile .
 greenprint "Pushing bootc container to quay.io"
 podman push quay.io/${QUAY_USERNAME}/greenboot-bootc:${TEST_UUID}
@@ -337,7 +374,7 @@ sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" ${EDGE_USER}@${GUEST_ADDRESS} "echo
 sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" ${EDGE_USER}@${GUEST_ADDRESS} "echo ${EDGE_USER_PASSWORD} |nohup sudo -S systemctl reboot &>/dev/null & exit"
 
 # Wait vm to finish the fallback
-sleep 240
+sleep 300
 
 # Check for ssh ready to go.
 greenprint "🛃 Checking for SSH is ready to go"

--- a/tests/greenboot-bootc.yaml
+++ b/tests/greenboot-bootc.yaml
@@ -122,11 +122,6 @@
     # case: check greenboot-set-rollback-trigger log at first boot
     - name: check greenboot-set-rollback-trigger at first boot
       block:
-        - name: systemd update done log should be found here
-          command: journalctl -b -7 -u systemd-update-done.service
-          become: yes
-          register: result_systemd_update_log
-
         - name: greenboot rollback trigger should be found here
           command: journalctl -b -7 -u greenboot-set-rollback-trigger.service
           become: yes
@@ -134,7 +129,6 @@
 
         - assert:
             that:
-              - "'Finished systemd-update-done.service - Update is Completed' in result_systemd_update_log.stdout"
               - "'Rollback trigger set successfully' in result_greenboot_trigger_log.stdout"
               - "'Dependency failed' not in result_greenboot_trigger_log.stdout"
             fail_msg: "Expected greenboot trigger log or systemd update log not found, or dependency failure found"
@@ -151,11 +145,6 @@
     # case: check greenboot-set-rollback-trigger log at boot after upgrade
     - name: check greenboot-set-rollback-trigger at boot after upgrade
       block:
-        - name: systemd update done log should be found here
-          command: journalctl -b -6 -u systemd-update-done.service
-          become: yes
-          register: result_systemd_update_log
-
         - name: greenboot rollback trigger should be found here
           command: journalctl -b -6 -u greenboot-set-rollback-trigger.service
           become: yes
@@ -163,8 +152,36 @@
 
         - assert:
             that:
-              - "'Finished systemd-update-done.service - Update is Completed' in result_systemd_update_log.stdout"
               - "'Rollback trigger set successfully' in result_greenboot_trigger_log.stdout"
+              - "'Dependency failed' not in result_greenboot_trigger_log.stdout"
+            fail_msg: "Expected greenboot trigger log not found, or dependency failure found"
+            success_msg: "Found expected log and no dependency failures"
+
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+
+    # case: check greenboot-set-rollback-trigger log at boot after fallback
+    - name: check greenboot-set-rollback-trigger at boot after fallback
+      block:
+        - name: systemd update done log should be found here
+          command: journalctl -b -0 -u systemd-update-done.service
+          become: yes
+          register: result_systemd_update_log
+
+        - name: greenboot rollback trigger should be found here
+          command: journalctl -b -0 -u greenboot-set-rollback-trigger.service
+          become: yes
+          register: result_greenboot_trigger_log
+
+        - assert:
+            that:
+              - "'Update is Completed skipped, no trigger condition checks were met' in result_systemd_update_log.stdout"
+              - "'Greenboot Rollback trigger skipped, no trigger condition checks were met' in result_greenboot_trigger_log.stdout"
               - "'Dependency failed' not in result_greenboot_trigger_log.stdout"
             fail_msg: "Expected greenboot trigger log or systemd update log not found, or dependency failure found"
             success_msg: "Found expected log and no dependency failures"
@@ -176,6 +193,8 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
+      when:
+        - ansible_facts['distribution'] == "Fedora"
 
     # case: check greenboot-set-rollback-trigger log at boot after fallback
     - name: check greenboot-set-rollback-trigger at boot after fallback
@@ -205,6 +224,8 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
+      when:
+        - (ansible_facts['distribution'] == 'CentOS') or (ansible_facts['distribution'] == 'RedHat')
 
     # case: check disable health checks
     - name: check disable health checks

--- a/tests/greenboot-ostree.sh
+++ b/tests/greenboot-ostree.sh
@@ -64,7 +64,7 @@ sudo localectl set-locale LANG=en_US.UTF-8
 
 # Install required packages
 greenprint "Install required packages"
-sudo dnf install -y --nogpgcheck httpd osbuild osbuild-composer composer-cli ansible-core createrepo_c podman qemu-img firewalld qemu-kvm libvirt-client libvirt-daemon-kvm libvirt-daemon virt-install rpmdevtools cargo lorax gobject-introspection
+sudo dnf install -y --nogpgcheck httpd osbuild osbuild-composer composer-cli ansible-core createrepo_c podman qemu-img firewalld qemu-kvm libvirt-client libvirt-daemon-kvm libvirt-daemon virt-install rpmdevtools cargo lorax gobject-introspection make rpm-build rust-toolset
 
 # Avoid collection installation filed sometime
 for _ in $(seq 0 30); do
@@ -87,8 +87,13 @@ case "${ID}-${VERSION_ID}" in
         BOOT_ARGS="uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
         CURRENT_COMPOSE_CS9=$(curl -s "https://composes.stream.centos.org/production/" | grep -ioE ">CentOS-Stream-9-.*/<" | tr -d '>/<' | tail -1)
         BOOT_LOCATION="https://composes.stream.centos.org/production/${CURRENT_COMPOSE_CS9}/compose/BaseOS/x86_64/os/"
-        sudo dnf install -y make rpm-build rust-toolset
         sudo cp files/centos-stream-9.json /etc/osbuild-composer/repositories/centos-9.json;;
+    "rhel-9.8")
+        OSTREE_REF="rhel/9/${ARCH}/edge"
+        OS_VARIANT="rhel9-unknown"
+        BOOT_ARGS="uefi"
+        BOOT_LOCATION="http://${DOWNLOAD_NODE}/rhel-9/nightly/RHEL-9/latest-RHEL-9.8.0/compose/BaseOS/x86_64/os/"
+        sed "s/REPLACE_ME_HERE/${DOWNLOAD_NODE}/g" files/rhel-9-8-0.json | sudo tee /etc/osbuild-composer/repositories/rhel-98.json > /dev/null;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;

--- a/tests/greenboot-ostree.yaml
+++ b/tests/greenboot-ostree.yaml
@@ -84,9 +84,9 @@
           ignore_errors: yes
           ignore_unreachable: yes
 
-        - name: delay 60 seconds before reboot to make system stable
+        - name: delay 300 seconds before reboot to make system stable
           pause:
-            seconds: 60
+            seconds: 300
           delegate_to: 127.0.0.1
 
         - name: wait for connection to become reachable/usable


### PR DESCRIPTION
This PR includes:
1. add RHEL9.8 ostree test in CI
2. add RHEL10.2 bootc test in CI
3. move fedora-44 test to fedora-45 (In testing-farm, fedora-rawhide is mapping to fedora-45 but fedora-44 is not available, will add it back when 44 is available in tmt.  Raised this question in tmt channel and they are working on it now. )
4. disable cs9 test for now ( add it back after fix https://github.com/osbuild/images/pull/2251 landed in cs9)



Please be noted that the new test  (rhel9.8-ostree and rhel10.2-bootc) added in pr will not run, until this pr is merged, the changes in github action file only take effect in main branch.

Currently this pr will run these cases:
1. fedora-43-bootc, should PASS
2. fedora-44-bootc, should PASS (although it is testing on fedora-45)
3. cs9-ostree, should FAIL because bootloalder issue
4. cs10-bootc, should PASS

And new added test will not run until this pr merged
1. rhel9.8-ostree
2. rhel10.2-bootc