### PR TITLE
Fix deployment type detection

### DIFF
--- a/.github/spellcheck-ignore
+++ b/.github/spellcheck-ignore
@@ -10,3 +10,4 @@ RO
 RW
 grubenv
 msdos
+waitFor

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4"
 clap = { version = "4.0", features = ["derive"] }
 config = "0.15.13"
 pretty_env_logger = "0.5.0"
-nix = "0.30.1"
+nix = "0.31.1"
 glob = "0.3.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "greenboot"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/greenboot-rs.spec
+++ b/greenboot-rs.spec
@@ -7,7 +7,7 @@
 %bcond bundled_rust_deps %{defined rhel}
 
 Name:		greenboot-rs
-Version:	0.16.2
+Version:	0.16.3
 Release:	0%{?dist}
 Summary:	Generic Health Check Framework for systemd
 # Aggregated license of statically linked dependencies as per %%cargo_license_summary

--- a/src/lib/handler.rs
+++ b/src/lib/handler.rs
@@ -38,23 +38,17 @@ pub fn detect_os_deployment() -> Option<&'static str> {
         }
     };
 
-    match json
+    if let Some(image_type) = json
         .get("status")
         .and_then(|s| s.get("booted"))
         .and_then(|b| b.get("image"))
+        .filter(|v| !v.is_null())
     {
-        Some(image) if image.is_null() => {
-            log::info!("System detected as rpm-ostree (status.booted.image is null)");
-            Some("rpm-ostree")
-        }
-        Some(_) => {
-            log::info!("System detected as bootc (status.booted.image is present)");
-            Some("bootc")
-        }
-        None => {
-            log::error!("bootc status JSON missing field status.booted.image");
-            None
-        }
+        log::info!("System detected as bootc (status.booted.image: {image_type})");
+        Some("bootc")
+    } else {
+        log::info!("System detected as rpm-ostree (status.booted.image is null or absent)");
+        Some("rpm-ostree")
     }
 }
 

--- a/src/lib/handler.rs
+++ b/src/lib/handler.rs
@@ -2,14 +2,21 @@
 
 use anyhow::{Context, Result, anyhow, bail};
 use serde_json::Value;
+use std::path::Path;
 use std::process::Command;
 use std::str;
 
 use crate::grub::get_boot_counter;
 
-/// Detects if the system is managed by bootc or is a rpm-ostree system
-/// Inspect bootc status JSON and decide based on `status.booted.incompatible`.
+/// Detects if the system is managed by bootc or is a rpm-ostree system.
+/// First checks for `/run/ostree-booted`, then inspects `status.booted.image`
+/// from `bootc status --booted --json` to distinguish between the two.
 pub fn detect_os_deployment() -> Option<&'static str> {
+    if !Path::new("/run/ostree-booted").exists() {
+        log::info!("'/run/ostree-booted' not found, not an ostree-based system");
+        return None;
+    }
+
     let output = match Command::new("bootc")
         .args(["status", "--booted", "--json"])
         .output()
@@ -34,19 +41,18 @@ pub fn detect_os_deployment() -> Option<&'static str> {
     match json
         .get("status")
         .and_then(|s| s.get("booted"))
-        .and_then(|b| b.get("incompatible"))
-        .and_then(|i| i.as_bool())
+        .and_then(|b| b.get("image"))
     {
-        Some(true) => {
-            log::info!("System detected as rpm-ostree (incompatible=true)");
+        Some(image) if image.is_null() => {
+            log::info!("System detected as rpm-ostree (status.booted.image is null)");
             Some("rpm-ostree")
         }
-        Some(false) => {
-            log::info!("System detected as bootc (incompatible=false)");
+        Some(_) => {
+            log::info!("System detected as bootc (status.booted.image is present)");
             Some("bootc")
         }
         None => {
-            log::error!("bootc status JSON missing boolean field status.booted.incompatible");
+            log::error!("bootc status JSON missing field status.booted.image");
             None
         }
     }


### PR DESCRIPTION
Use booted.image to detect between rpm-ostree or bootc
if its null then use rpm-ostree verb else bootc.

fixes: https://issues.redhat.com/browse/RHEL-154238