### PR TITLE
Log script stdout/stderr on success

### DIFF
--- a/src/lib/greenboot.rs
+++ b/src/lib/greenboot.rs
@@ -158,6 +158,14 @@ fn run_scripts(name: &str, path: &str, disabled_scripts: Option<&[String]>) -> S
         match output {
             Ok(o) if o.status.success() => {
                 log::info!("{} script {} success!", name, entry.to_string_lossy());
+                let stdout = String::from_utf8_lossy(&o.stdout);
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                if !stdout.trim().is_empty() {
+                    log::info!("{}", stdout.trim_end());
+                }
+                if !stderr.trim().is_empty() {
+                    log::warn!("{}", stderr.trim_end());
+                }
             }
             Ok(o) => {
                 let error_msg = format!(


### PR DESCRIPTION
## Problem

When scripts in `red.d/`, `green.d/`, `required.d/`, or `wanted.d/` exit successfully, their stdout/stderr output is silently discarded. Only a brief `"<name> script <path> success!"` message is logged.

This is a problem for **pre-rollback scripts** (`red.d/`) that collect diagnostic information (agent status, journal logs, system state) before a rollback occurs. After the rollback reboot, the diagnostic output is lost, making post-mortem analysis impossible.

Shell greenboot (0.15.x) captured all script output via `systemd-cat` in `redboot-task-runner.service`. greenboot-rs lost this behavior.

## Fix

In `run_scripts()`, after a script exits successfully, log stdout at `info` level and stderr at `warn` level (only if non-empty). This restores parity with shell greenboot's output capture behavior.

## Impact

- `red.d/` pre-rollback diagnostic scripts: output now visible in `journalctl -u greenboot-healthcheck` after rollback
- `green.d/` / `required.d/` / `wanted.d/` scripts: output now visible for debugging, previously silent on success

Fixes: #141