### PR TITLE
fix(ci): update workflows latest actions that run on node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check spelling
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check spelling
         uses: codespell-project/actions-codespell@master
         with:
@@ -25,7 +25,7 @@ jobs:
     name: Cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install deps
         run: |
           dnf install -y make gcc git clippy cargo rust
@@ -62,7 +62,7 @@ jobs:
       - name: Install deps
         run: |
           dnf install -y make gcc git cargo rust git grub2-efi grub2-efi-modules shim llvm
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Fix git trust

--- a/.github/workflows/comment-ci.yaml
+++ b/.github/workflows/comment-ci.yaml
@@ -12,14 +12,14 @@ jobs:
             (endsWith(github.event.comment.body, '/test')) }}
     steps:
       - name: Get information for pull request
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         id: pr-api
         with:
           route: GET /repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Query author repository permissions
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         id: user_permission
         with:
           route: GET /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission

--- a/.github/workflows/greenboot-ci.yaml
+++ b/.github/workflows/greenboot-ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Query author repository permissions
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         id: user_permission
         with:
           route: GET /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission
@@ -25,7 +25,7 @@ jobs:
           echo "allowed_user=true" >> $GITHUB_OUTPUT
 
       - name: Get information for pull request
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         id: pr-api
         with:
           route: GET /repos/${{ github.repository }}/pulls/${{ github.event.number }}


### PR DESCRIPTION
This PR tries to avoid deprecation message on github actions workflow runs:

```
check-pull-request
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: octokit/request-action@v2.x. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```
Since Node20 will reach end-of-life (EOL) in April of 2026, it is mentioned in https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/ that we should Update our workflows with latest versions of the actions that run on Node24.