### PR TITLE
fix(ci): use tf public ranch resources in fedora and centos workflow jobs

### DIFF
--- a/.github/workflows/greenboot-ci.yaml
+++ b/.github/workflows/greenboot-ci.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
           compose: CentOS-Stream-10
-          api_key: ${{ secrets.TF_API_KEY }}
+          api_key: ${{ secrets.TF_API_PUB_KEY }}
           git_url: ${{ needs.check-pull-request.outputs.repo_url }}
           git_ref: ${{ needs.check-pull-request.outputs.ref }}
           update_pull_request_status: true
@@ -72,7 +72,7 @@ jobs:
         uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
           compose: Fedora-44
-          api_key: ${{ secrets.TF_API_KEY }}
+          api_key: ${{ secrets.TF_API_PUB_KEY }}
           git_url: ${{ needs.check-pull-request.outputs.repo_url }}
           git_ref: ${{ needs.check-pull-request.outputs.ref }}
           update_pull_request_status: true
@@ -95,7 +95,7 @@ jobs:
         uses: sclorg/testing-farm-as-github-action@v3.1.2
         with:
           compose: Fedora-Rawhide
-          api_key: ${{ secrets.TF_API_KEY }}
+          api_key: ${{ secrets.TF_API_PUB_KEY }}
           git_url: ${{ needs.check-pull-request.outputs.repo_url }}
           git_ref: ${{ needs.check-pull-request.outputs.ref }}
           update_pull_request_status: true

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -40,7 +40,7 @@ case "${ID}-${VERSION_ID}" in
         sudo dnf install -y rpmbuild rust-packaging
         ;;
     "fedora-44")
-        OS_VARIANT="fedora-44"
+        OS_VARIANT="fedora-unknown"
         BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:44"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -40,7 +40,7 @@ case "${ID}-${VERSION_ID}" in
         sudo dnf install -y rpmbuild rust-packaging
         ;;
     "fedora-44")
-        OS_VARIANT="fedora-44"
+        OS_VARIANT="fedora-unknown"
         BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:44"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"


### PR DESCRIPTION
This pull request proposes changes to update Fedora/CentOS workflow jobs, enabling them to utilize Testing Farm Public Ranch resources. This modification will allow test execution whenever the workflows are triggered by external contributors.