### PR TITLE
ci: add layered package into deployments to verify incompatible flag bug fix

### DIFF
--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -40,7 +40,7 @@ case "${ID}-${VERSION_ID}" in
         sudo dnf install -y rpmbuild rust-packaging
         ;;
     "fedora-44")
-        OS_VARIANT="fedora-44"
+        OS_VARIANT="fedora-unknown"
         BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:44"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -40,7 +40,7 @@ case "${ID}-${VERSION_ID}" in
         sudo dnf install -y rpmbuild rust-packaging
         ;;
     "fedora-44")
-        OS_VARIANT="fedora-44"
+        OS_VARIANT="fedora-unknown"
         BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:44"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"

--- a/tests/greenboot-ostree.yaml
+++ b/tests/greenboot-ostree.yaml
@@ -75,7 +75,75 @@
       shell: findmnt -r -o OPTIONS -n /boot | awk -F "," '{print $1}'
       register: result_boot_mount_before
 
-    # case: check rollback function if boot error found
+    # case: install layered package to reproduce incompatible flag rollback bug
+    - name: verify tree is not already present in base deployment
+      block:
+        - name: check tree is not installed
+          command: rpm -q tree
+          register: result_tree_precheck
+          failed_when: result_tree_precheck.rc == 0
+
+        - assert:
+            that:
+              - result_tree_precheck.rc != 0
+            fail_msg: "tree is already in the base image - pick a different layered package for this test"
+            success_msg: "tree is not in the base image, safe to use as layered package"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+
+    - name: install layered package (tree) to create deployment with incompatible flag
+      block:
+        - name: install tree as layered package via rpm-ostree
+          command: rpm-ostree install tree --reboot
+          become: yes
+          ignore_errors: yes
+          ignore_unreachable: yes
+
+        - name: delay 300 seconds for layered package reboot
+          pause:
+            seconds: 300
+          delegate_to: 127.0.0.1
+
+        - name: wait for connection after layered package reboot
+          wait_for_connection:
+            delay: 30
+
+        - name: wait until instance is reachable after layered package reboot
+          wait_for:
+            host: "{{ ansible_all_ipv4_addresses[0] }}"
+            port: 22
+            search_regex: OpenSSH
+            delay: 10
+          register: result_layered_pkg
+          until: result_layered_pkg is success
+          retries: 6
+          delay: 10
+
+        - name: verify tree was installed as layered package
+          command: rpm -q tree
+          become: yes
+          register: result_tree_verify
+
+        - assert:
+            that:
+              - result_layered_pkg is succeeded
+              - result_tree_verify.rc == 0
+            fail_msg: "Layered package installation failed"
+            success_msg: "Layered package (tree) installed successfully"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+
+    # case: check rollback function if boot error found (with layered package present)
     - name: install sanely failing health check unit to test red boot status behavior
       block:
         - name: install sanely failing health check unit to test red boot status behavior
@@ -117,6 +185,27 @@
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
 
+    # case: verify layered package persists after rollback
+    - name: verify layered package (tree) is present after rollback
+      block:
+        - name: check tree is still installed after rollback
+          command: rpm -q tree
+          register: result_tree_after_rollback
+
+        - assert:
+            that:
+              - result_tree_after_rollback.rc == 0
+            fail_msg: "tree not found after rollback - system rolled back to wrong deployment"
+            success_msg: "tree present after rollback - correct deployment restored"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: result_rollback is defined and result_rollback is succeeded
+
     # case: check fallback log
     - name: fallback log should be found here
       block:
@@ -138,7 +227,7 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
-      when: result_rollback is succeeded
+      when: result_rollback is defined and result_rollback is succeeded
 
     # case: check boot-complete.target status
     - name: boot-complete.target should be active

--- a/tests/greenboot-ostree.yaml
+++ b/tests/greenboot-ostree.yaml
@@ -99,30 +99,14 @@
     - name: install layered package (tree) to create deployment with incompatible flag
       block:
         - name: install tree as layered package via rpm-ostree
-          command: rpm-ostree install tree --reboot
+          command: rpm-ostree install tree
           become: yes
-          ignore_errors: yes
-          ignore_unreachable: yes
 
-        - name: delay 300 seconds for layered package reboot
-          pause:
-            seconds: 300
-          delegate_to: 127.0.0.1
-
-        - name: wait for connection after layered package reboot
-          wait_for_connection:
-            delay: 30
-
-        - name: wait until instance is reachable after layered package reboot
-          wait_for:
-            host: "{{ ansible_all_ipv4_addresses[0] }}"
-            port: 22
-            search_regex: OpenSSH
-            delay: 10
-          register: result_layered_pkg
-          until: result_layered_pkg is success
-          retries: 6
-          delay: 10
+        - name: reboot to apply layered package
+          reboot:
+            reboot_timeout: 600
+            post_reboot_delay: 30
+          become: yes
 
         - name: verify tree was installed as layered package
           command: rpm -q tree
@@ -131,7 +115,6 @@
 
         - assert:
             that:
-              - result_layered_pkg is succeeded
               - result_tree_verify.rc == 0
             fail_msg: "Layered package installation failed"
             success_msg: "Layered package (tree) installed successfully"


### PR DESCRIPTION
This is a suggested verification that allows the proper recognition of the ostree deployments.

This PR installs a layered package (tree) via rpm-ostree before deploying the failing health check unit, so that the test ensures the rollback target has the incompatible flag set. That is, the PR verifies applied fix in v0.16.3 https://github.com/fedora-iot/greenboot-rs/pull/165

Prior to the fix, greenboot misinterpreted ostree deployment states when layered packages were present, but we had no automation configured to detect this situation.

These changes validate that greenboot is able to roll back when the target deployment has the incompatible flag set due to layered packages.

In order to fix the following issue:
`ERROR    Unknown OS name 'fedora-44'. See --osinfo list for valid values.`
This PR also updates `OS_VARIANT` variable to the expected os name.