### PR TITLE
Enable ostree testing and fix Testing Farm status permissions

### DIFF
--- a/.github/workflows/comment-ci.yaml
+++ b/.github/workflows/comment-ci.yaml
@@ -45,6 +45,8 @@ jobs:
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
     continue-on-error: true
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
 
     steps:
       - name: Run the tests
@@ -68,6 +70,8 @@ jobs:
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
     continue-on-error: true
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
 
     steps:
       - name: Run the tests
@@ -91,6 +95,8 @@ jobs:
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
     continue-on-error: true
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
 
     steps:
       - name: Run the tests
@@ -109,59 +115,63 @@ jobs:
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
-  # TODO: uncomment once fix https://github.com/osbuild/images/pull/2251 is landed in CS9
-  # centos-9-ostree:
-  #   needs: check-pull-request
-  #   if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
-  #   continue-on-error: true
-  #   runs-on: ubuntu-latest
+  centos-9-ostree:
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
 
-  #   steps:
-  #     - name: Run the tests
-  #       uses: sclorg/testing-farm-as-github-action@270f0d1d89dad513588fb5cc2cdd512c3459f3fe # v3.1.2
-  #       with:
-  #         compose: CentOS-Stream-9
-  #         api_key: ${{ secrets.TF_API_KEY }}
-  #         git_url: ${{ needs.check-pull-request.outputs.repo_url }}
-  #         git_ref: ${{ needs.check-pull-request.outputs.ref }}
-  #         update_pull_request_status: true
-  #         pull_request_status_name: centos-9-ostree
-  #         tmt_context: "arch=x86_64;distro=cs-9"
-  #         tmt_plan_regex: ostree
-  #         tf_scope: private
-  #         variables: "ARCH=x86_64"
-  #         timeout: 90
-  #         secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
+    steps:
+      - name: Run the tests
+        uses: sclorg/testing-farm-as-github-action@270f0d1d89dad513588fb5cc2cdd512c3459f3fe # v3.1.2
+        with:
+          compose: CentOS-Stream-9
+          api_key: ${{ secrets.TF_API_KEY }}
+          git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+          git_ref: ${{ needs.check-pull-request.outputs.ref }}
+          update_pull_request_status: true
+          pull_request_status_name: centos-9-ostree
+          tmt_context: "arch=x86_64;distro=cs-9"
+          tmt_plan_regex: ostree
+          tf_scope: private
+          variables: "ARCH=x86_64"
+          timeout: 90
+          secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
-  # TODO: uncomment once fix https://github.com/osbuild/images/pull/2251 is landed in RHEL9.8
-  # rhel-9-8-ostree:
-  #   needs: check-pull-request
-  #   if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
-  #   continue-on-error: true
-  #   runs-on: ubuntu-latest
+  rhel-9-8-ostree:
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
 
-  #   steps:
-  #     - name: Run the tests
-  #       uses: sclorg/testing-farm-as-github-action@270f0d1d89dad513588fb5cc2cdd512c3459f3fe # v3.1.2
-  #       with:
-  #         compose: RHEL-9.8.0-Nightly
-  #         api_key: ${{ secrets.TF_API_KEY }}
-  #         git_url: ${{ needs.check-pull-request.outputs.repo_url }}
-  #         git_ref: ${{ needs.check-pull-request.outputs.ref }}
-  #         update_pull_request_status: true
-  #         pull_request_status_name: rhel-9.8-ostree
-  #         tmt_context: "arch=x86_64;distro=rhel-9-8"
-  #         tmt_plan_regex: ostree
-  #         tf_scope: private
-  #         variables: "ARCH=x86_64"
-  #         timeout: 90
-  #         secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
+    steps:
+      - name: Run the tests
+        uses: sclorg/testing-farm-as-github-action@270f0d1d89dad513588fb5cc2cdd512c3459f3fe # v3.1.2
+        with:
+          compose: RHEL-9.8.0-Nightly
+          api_key: ${{ secrets.TF_API_KEY }}
+          git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+          git_ref: ${{ needs.check-pull-request.outputs.ref }}
+          update_pull_request_status: true
+          pull_request_status_name: rhel-9.8-ostree
+          tmt_context: "arch=x86_64;distro=rhel-9-8"
+          tmt_plan_regex: ostree
+          tf_scope: private
+          variables: "ARCH=x86_64"
+          timeout: 90
+          secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
   rhel-10-2-bootc:
     needs: check-pull-request
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
     continue-on-error: true
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
 
     steps:
       - name: Run the tests

--- a/.github/workflows/greenboot-ci.yaml
+++ b/.github/workflows/greenboot-ci.yaml
@@ -45,6 +45,8 @@ jobs:
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
     continue-on-error: true
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
 
     steps:
       - name: Run the tests
@@ -68,6 +70,8 @@ jobs:
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
     continue-on-error: true
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
 
     steps:
       - name: Run the tests
@@ -91,6 +95,8 @@ jobs:
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
     continue-on-error: true
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
 
     steps:
       - name: Run the tests
@@ -109,59 +115,63 @@ jobs:
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
-  # TODO: uncomment once fix https://github.com/osbuild/images/pull/2251 is landed in CS9
-  # centos-9-ostree:
-  #   needs: check-pull-request
-  #   if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
-  #   continue-on-error: true
-  #   runs-on: ubuntu-latest
+  centos-9-ostree:
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
 
-  #   steps:
-  #     - name: Run the tests
-  #       uses: sclorg/testing-farm-as-github-action@270f0d1d89dad513588fb5cc2cdd512c3459f3fe # v3.1.2
-  #       with:
-  #         compose: CentOS-Stream-9
-  #         api_key: ${{ secrets.TF_API_KEY }}
-  #         git_url: ${{ needs.check-pull-request.outputs.repo_url }}
-  #         git_ref: ${{ needs.check-pull-request.outputs.ref }}
-  #         update_pull_request_status: true
-  #         pull_request_status_name: centos-9-ostree
-  #         tmt_context: "arch=x86_64;distro=cs-9"
-  #         tmt_plan_regex: ostree
-  #         tf_scope: private
-  #         variables: "ARCH=x86_64"
-  #         timeout: 90
-  #         secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
+    steps:
+      - name: Run the tests
+        uses: sclorg/testing-farm-as-github-action@270f0d1d89dad513588fb5cc2cdd512c3459f3fe # v3.1.2
+        with:
+          compose: CentOS-Stream-9
+          api_key: ${{ secrets.TF_API_KEY }}
+          git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+          git_ref: ${{ needs.check-pull-request.outputs.ref }}
+          update_pull_request_status: true
+          pull_request_status_name: centos-9-ostree
+          tmt_context: "arch=x86_64;distro=cs-9"
+          tmt_plan_regex: ostree
+          tf_scope: private
+          variables: "ARCH=x86_64"
+          timeout: 90
+          secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
-  # TODO: uncomment once fix https://github.com/osbuild/images/pull/2251 is landed in RHEL9.8
-  # rhel-9-8-ostree:
-  #   needs: check-pull-request
-  #   if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
-  #   continue-on-error: true
-  #   runs-on: ubuntu-latest
+  rhel-9-8-ostree:
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
 
-  #   steps:
-  #     - name: Run the tests
-  #       uses: sclorg/testing-farm-as-github-action@270f0d1d89dad513588fb5cc2cdd512c3459f3fe # v3.1.2
-  #       with:
-  #         compose: RHEL-9.8.0-Nightly
-  #         api_key: ${{ secrets.TF_API_KEY }}
-  #         git_url: ${{ needs.check-pull-request.outputs.repo_url }}
-  #         git_ref: ${{ needs.check-pull-request.outputs.ref }}
-  #         update_pull_request_status: true
-  #         pull_request_status_name: rhel-9.8-ostree
-  #         tmt_context: "arch=x86_64;distro=rhel-9-8"
-  #         tmt_plan_regex: ostree
-  #         tf_scope: private
-  #         variables: "ARCH=x86_64"
-  #         timeout: 90
-  #         secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
+    steps:
+      - name: Run the tests
+        uses: sclorg/testing-farm-as-github-action@270f0d1d89dad513588fb5cc2cdd512c3459f3fe # v3.1.2
+        with:
+          compose: RHEL-9.8.0-Nightly
+          api_key: ${{ secrets.TF_API_KEY }}
+          git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+          git_ref: ${{ needs.check-pull-request.outputs.ref }}
+          update_pull_request_status: true
+          pull_request_status_name: rhel-9.8-ostree
+          tmt_context: "arch=x86_64;distro=rhel-9-8"
+          tmt_plan_regex: ostree
+          tf_scope: private
+          variables: "ARCH=x86_64"
+          timeout: 90
+          secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
   rhel-10-2-bootc:
     needs: check-pull-request
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
     continue-on-error: true
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
 
     steps:
       - name: Run the tests


### PR DESCRIPTION
- Uncomment CentOS Stream 9 and RHEL 9.8 ostree CI jobs (blocker osbuild/images#2251 merged)
- Add job-level `permissions: statuses: write` to all Testing Farm jobs to fix "Resource not accessible by integration" error caused by workflow-level `permissions: read-all` 
