### PR TITLE
spec: fix for leap container installation

### DIFF
--- a/greenboot-rs.spec
+++ b/greenboot-rs.spec
@@ -34,7 +34,7 @@ automated rollback actions if it's not.
 
 %package -n %{pkgname}
 Summary:	%{summary}
-%{?systemd_requires}
+%{?systemd_ordering}
 Requires:	systemd >= 240
 Requires:	rpm-ostree
 Requires:	pam >= 1.4.0
@@ -101,14 +101,18 @@ install -DpZm 0755 usr/lib/greenboot/check/wanted.d/* %{buildroot}%{_prefix}/lib
 install -DpZm 0644 usr/lib/systemd/system/greenboot-healthcheck.service.d/10-network-online.conf %{buildroot}%{_unitdir}/greenboot-healthcheck.service.d/10-network-online.conf
 
 %post -n %{pkgname}
+if [ -d /run/systemd/system ]; then
 %systemd_post greenboot-healthcheck.service
 %systemd_post greenboot-set-rollback-trigger.service
 %systemd_post greenboot-success.target
+fi
 
 %preun -n %{pkgname}
+if [ -d /run/systemd/system ]; then
 %systemd_preun greenboot-healthcheck.service
 %systemd_preun greenboot-set-rollback-trigger.service
 %systemd_preun greenboot-success.target
+fi
 
 %postun -n %{pkgname}
 %systemd_postun greenboot-healthcheck.service


### PR DESCRIPTION
service enablement is tied to check if systemd booted.