### PR TITLE
ci: switch tests to Packit Copr PR builds

### DIFF
--- a/.github/workflows/comment-ci.yaml
+++ b/.github/workflows/comment-ci.yaml
@@ -41,6 +41,26 @@ jobs:
       repo_url: ${{ fromJson(steps.pr-api.outputs.data).head.repo.html_url }}
       pr_number: ${{ github.event.issue.number }}
 
+  make-rpm:
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/centos/centos:stream9
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.check-pull-request.outputs.sha }}
+
+      - name: Build RPMs
+        run: |
+          dnf install -y git make rpm-build rust-toolset
+          make rpm
+
+      - name: Verify RPMs were created
+        run: ls rpmbuild/RPMS/*/*.rpm
+
   centos-10-bootc:
     needs: check-pull-request
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}

--- a/.github/workflows/comment-ci.yaml
+++ b/.github/workflows/comment-ci.yaml
@@ -39,6 +39,7 @@ jobs:
       sha: ${{ fromJson(steps.pr-api.outputs.data).head.sha }}
       ref: ${{ fromJson(steps.pr-api.outputs.data).head.ref }}
       repo_url: ${{ fromJson(steps.pr-api.outputs.data).head.repo.html_url }}
+      pr_number: ${{ github.event.issue.number }}
 
   centos-10-bootc:
     needs: check-pull-request
@@ -60,7 +61,7 @@ jobs:
           pull_request_status_name: centos-10-bootc
           tmt_context: "arch=x86_64;distro=cs-10"
           tmt_plan_regex: bootc
-          variables: "ARCH=x86_64"
+          variables: "ARCH=x86_64;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
@@ -84,7 +85,7 @@ jobs:
           pull_request_status_name: fedora-44-bootc
           tmt_context: "arch=x86_64;distro=fedora-44"
           tmt_plan_regex: bootc
-          variables: "ARCH=x86_64"
+          variables: "ARCH=x86_64;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
@@ -108,7 +109,7 @@ jobs:
           pull_request_status_name: fedora-45-bootc
           tmt_context: "arch=x86_64;distro=fedora-45"
           tmt_plan_regex: bootc
-          variables: "ARCH=x86_64"
+          variables: "ARCH=x86_64;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
@@ -132,7 +133,7 @@ jobs:
           pull_request_status_name: centos-9-ostree
           tmt_context: "arch=x86_64;distro=cs-9"
           tmt_plan_regex: ostree
-          variables: "ARCH=x86_64"
+          variables: "ARCH=x86_64;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
@@ -156,7 +157,7 @@ jobs:
           pull_request_status_name: rhel-9.8-ostree
           tmt_context: "arch=x86_64;distro=rhel-9-8"
           tmt_plan_regex: ostree
-          variables: "ARCH=x86_64"
+          variables: "ARCH=x86_64;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
@@ -180,6 +181,6 @@ jobs:
           pull_request_status_name: rhel-10.2-bootc
           tmt_context: "arch=x86_64;distro=rhel-10-2"
           tmt_plan_regex: bootc
-          variables: "ARCH=x86_64"
+          variables: "ARCH=x86_64;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"

--- a/.github/workflows/greenboot-ci.yaml
+++ b/.github/workflows/greenboot-ci.yaml
@@ -39,6 +39,7 @@ jobs:
       sha: ${{ fromJson(steps.pr-api.outputs.data).head.sha }}
       ref: ${{ fromJson(steps.pr-api.outputs.data).head.ref }}
       repo_url: ${{ fromJson(steps.pr-api.outputs.data).head.repo.html_url }}
+      pr_number: ${{ github.event.number }}
 
   centos-10-bootc:
     needs: check-pull-request
@@ -60,7 +61,7 @@ jobs:
           pull_request_status_name: centos-10-bootc
           tmt_context: "arch=x86_64;distro=cs-10"
           tmt_plan_regex: bootc
-          variables: "ARCH=x86_64"
+          variables: "ARCH=x86_64;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
@@ -84,7 +85,7 @@ jobs:
           pull_request_status_name: fedora-44-bootc
           tmt_context: "arch=x86_64;distro=fedora-44"
           tmt_plan_regex: bootc
-          variables: "ARCH=x86_64"
+          variables: "ARCH=x86_64;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
@@ -108,7 +109,7 @@ jobs:
           pull_request_status_name: fedora-45-bootc
           tmt_context: "arch=x86_64;distro=fedora-45"
           tmt_plan_regex: bootc
-          variables: "ARCH=x86_64"
+          variables: "ARCH=x86_64;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
@@ -132,7 +133,7 @@ jobs:
           pull_request_status_name: centos-9-ostree
           tmt_context: "arch=x86_64;distro=cs-9"
           tmt_plan_regex: ostree
-          variables: "ARCH=x86_64"
+          variables: "ARCH=x86_64;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
@@ -156,7 +157,7 @@ jobs:
           pull_request_status_name: rhel-9.8-ostree
           tmt_context: "arch=x86_64;distro=rhel-9-8"
           tmt_plan_regex: ostree
-          variables: "ARCH=x86_64"
+          variables: "ARCH=x86_64;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
@@ -180,6 +181,6 @@ jobs:
           pull_request_status_name: rhel-10.2-bootc
           tmt_context: "arch=x86_64;distro=rhel-10-2"
           tmt_plan_regex: bootc
-          variables: "ARCH=x86_64"
+          variables: "ARCH=x86_64;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"

--- a/.github/workflows/greenboot-ci.yaml
+++ b/.github/workflows/greenboot-ci.yaml
@@ -41,6 +41,26 @@ jobs:
       repo_url: ${{ fromJson(steps.pr-api.outputs.data).head.repo.html_url }}
       pr_number: ${{ github.event.number }}
 
+  make-rpm:
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/centos/centos:stream9
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.check-pull-request.outputs.sha }}
+
+      - name: Build RPMs
+        run: |
+          dnf install -y git make rpm-build rust-toolset
+          make rpm
+
+      - name: Verify RPMs were created
+        run: ls rpmbuild/RPMS/*/*.rpm
+
   centos-10-bootc:
     needs: check-pull-request
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,8 +13,6 @@ upstream_tag_template: v{version}
 copy_upstream_release_description: true
 sync_changelog: true
 
-# Use clean release string without commit hashes/branch names
-release_suffix: ""
 
 srpm_build_deps:
   - cargo
@@ -35,18 +33,20 @@ actions:
   - "sed -i '/^%global forgeurl/d' greenboot-rs.spec"
   - "sed -i '/^%forgemeta/d' greenboot-rs.spec"
   - "sed -i '/^%forgeautosetup/d' greenboot-rs.spec"
+  - "sed -i '/^License:/a\\%global debug_package %{nil}' greenboot-rs.spec"
   - bash -c "git config user.name 'Packit Build' || true"
   - bash -c "git config user.email 'packit@fedoraproject.org' || true"
-  fix-spec-file:
-  # This runs after Packit's release processing - disable debug package to prevent saypaul error
-  - "sed -i '/^License:/a\\%global debug_package %{nil}' greenboot-rs.spec"
 
 jobs:
 - job: copr_build
   trigger: pull_request
   targets:
+  - centos-stream-9-aarch64
+  - centos-stream-9-x86_64
   - centos-stream-10-aarch64
   - centos-stream-10-x86_64
+  - fedora-44-aarch64
+  - fedora-44-x86_64
   - fedora-development-aarch64
   - fedora-development
   - fedora-eln-aarch64

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euox pipefail
 
+ARCH=$(uname -m)
+
 # Dumps details about the instance running the CI job.
 echo -e "\033[0;36m"
 cat << EOF
@@ -30,6 +32,7 @@ SSH_KEY=key/ostree_key
 SSH_KEY_PUB=$(cat "${SSH_KEY}".pub)
 EDGE_USER=core
 EDGE_USER_PASSWORD=foobar
+CONSOLE_LOG=/tmp/vm-console.log
 
 case "${ID}-${VERSION_ID}" in
     "fedora-43")
@@ -37,35 +40,30 @@ case "${ID}-${VERSION_ID}" in
         BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:43"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"
-        sudo dnf install -y rpmbuild rust-packaging
         ;;
     "fedora-44")
         OS_VARIANT="fedora-unknown"
         BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:44"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"
-        sudo dnf install -y rpmbuild rust-packaging
         ;;
     "fedora-45")
         OS_VARIANT="fedora-rawhide"
         BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:rawhide"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"
-        sudo dnf install -y rpmbuild rust-packaging
         ;;
     "centos-10")
         OS_VARIANT="centos-stream9"
         BASE_IMAGE_URL="quay.io/centos-bootc/centos-bootc:stream10"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
-        sudo dnf install -y make rpm-build rust-toolset
         ;;
     "rhel-9.8")
         OS_VARIANT="rhel9-unknown"
         BASE_IMAGE_URL="registry.stage.redhat.io/rhel9/rhel-bootc:9.8"
         BIB_URL="registry.stage.redhat.io/rhel9/bootc-image-builder:9.8"
         BOOT_ARGS="uefi"
-        sudo dnf install -y make rpm-build rust-toolset
         sed -i "s/REPLACE_ME_HERE/${DOWNLOAD_NODE}/g" files/rhel-9-8.repo
         ;;
     "rhel-10.2")
@@ -73,7 +71,6 @@ case "${ID}-${VERSION_ID}" in
         BASE_IMAGE_URL="registry.stage.redhat.io/rhel10/rhel-bootc:10.2"
         BIB_URL="registry.stage.redhat.io/rhel10/bootc-image-builder:10.2"
         BOOT_ARGS="uefi"
-        sudo dnf install -y make rpm-build rust-toolset
         sed -i "s/REPLACE_ME_HERE/${DOWNLOAD_NODE}/g" files/rhel-10-2.repo
         ;;
     *)
@@ -112,7 +109,7 @@ wait_for_ssh_up () {
 ##
 ###########################################################
 greenprint "Installing required packages"
-sudo dnf install -y podman qemu-img firewalld qemu-kvm libvirt-client libvirt-daemon-kvm libvirt-daemon virt-install rpmdevtools ansible-core cargo lorax gobject-introspection
+sudo dnf install -y podman qemu-img firewalld qemu-kvm libvirt-client libvirt-daemon-kvm libvirt-daemon virt-install ansible-core lorax gobject-introspection
 ansible-galaxy collection install community.general
 
 # Start firewalld
@@ -174,17 +171,17 @@ fi
 
 ###########################################################
 ##
-## Build greenboot rpm packages
+## Copy test assets
 ##
 ###########################################################
-greenprint "Building greenboot packages"
-pushd .. && \
-make rpm
-cp rpmbuild/RPMS/x86_64/*.rpm tests/
-cp testing_assets/passing_script.sh tests/
-cp testing_assets/passing_binary tests/
-cp testing_assets/failing_script.sh tests/
-cp testing_assets/failing_binary tests/ && popd
+greenprint "Copying test assets"
+(
+    cd ..
+    cp testing_assets/passing_script.sh tests/
+    cp testing_assets/passing_binary tests/
+    cp testing_assets/failing_script.sh tests/
+    cp testing_assets/failing_binary tests/
+)
 
 ###########################################################
 ##
@@ -196,10 +193,9 @@ podman login quay.io -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD}
 podman login registry.stage.redhat.io -u ${STAGE_REDHAT_IO_USERNAME} -p ${STAGE_REDHAT_IO_TOKEN}
 tee Containerfile > /dev/null << EOF
 FROM ${BASE_IMAGE_URL}
-# Copy the local RPM files into the container
-COPY greenboot-*.rpm /tmp/
-RUN dnf install -y \
-    /tmp/greenboot-*.rpm && \
+RUN dnf install -y 'dnf-command(copr)' && \
+    dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUMBER} && \
+    dnf install -y greenboot greenboot-default-health-checks && \
     systemctl enable greenboot-healthcheck.service
 RUN sed -i "s/GREENBOOT_MAX_BOOT_ATTEMPTS=3/GREENBOOT_MAX_BOOT_ATTEMPTS=5/g" /etc/greenboot/greenboot.conf
 RUN sed -i 's#DISABLED_HEALTHCHECKS=()#DISABLED_HEALTHCHECKS=("01_repository_dns_check.sh" "not_exit.sh")#g' /etc/greenboot/greenboot.conf
@@ -216,8 +212,6 @@ COPY failing_script.sh /etc/greenboot/red.d
 
 COPY passing_binary /etc/greenboot/check/required.d/
 COPY failing_binary /etc/greenboot/check/wanted.d/
-# Clean up by removing the local RPMs if desired
-RUN rm -f /tmp/greenboot-*.rpm
 EOF
 
 if [[ "${ID}-${VERSION_ID}" == "rhel-9.8" ]]; then
@@ -232,7 +226,22 @@ COPY files/rhel-10-2.repo /etc/yum.repos.d/rhel-10-2.repo
 EOF
 fi
 
-podman build  --retry=5 --retry-delay=10s -t quay.io/${QUAY_USERNAME}/greenboot-bootc:${TEST_UUID} -f Containerfile .
+greenprint "Building container (retrying until Copr build is available)"
+build_success=false
+for attempt in $(seq 1 10); do
+    if podman build --retry=5 --retry-delay=10s -t quay.io/${QUAY_USERNAME}/greenboot-bootc:${TEST_UUID} -f Containerfile .; then
+        build_success=true
+        break
+    fi
+    greenprint "Container build attempt ${attempt}/10 failed, retrying in 60s..."
+    sleep 60
+done
+
+if [ "$build_success" = false ]; then
+    echo "Container build failed after 10 attempts."
+    exit 1
+fi
+
 greenprint "Pushing bootc container to quay.io"
 podman push quay.io/${QUAY_USERNAME}/greenboot-bootc:${TEST_UUID}
 
@@ -329,7 +338,8 @@ sudo virt-install  --name="${TEST_UUID}-uefi"\
                    --os-variant ${OS_VARIANT} \
                    --cdrom "/var/lib/libvirt/images/install.iso" \
                    --boot ${BOOT_ARGS} \
-                   --nographics \
+                   --graphics none \
+                   --serial file,path=${CONSOLE_LOG} \
                    --noautoconsole \
                    --wait=-1 \
                    --noreboot
@@ -346,6 +356,14 @@ for _ in $(seq 0 30); do
     fi
     sleep 10
 done
+
+if [[ $RESULTS != 1 ]]; then
+    greenprint "SSH failed on initial boot — collecting VM diagnostics"
+    sudo virsh domstate "${TEST_UUID}-uefi" || true
+    sudo virsh net-dhcp-leases integration || true
+    greenprint "VM console output (last 100 lines):"
+    sudo tail -100 ${CONSOLE_LOG} 2>/dev/null || true
+fi
 check_result
 
 ###########################################################
@@ -386,6 +404,14 @@ for _ in $(seq 0 30); do
     fi
     sleep 10
 done
+
+if [[ $RESULTS != 1 ]]; then
+    greenprint "SSH failed after upgrade — collecting VM diagnostics"
+    sudo virsh domstate "${TEST_UUID}-uefi" || true
+    sudo virsh net-dhcp-leases integration || true
+    greenprint "VM console output (last 100 lines):"
+    sudo tail -100 ${CONSOLE_LOG} 2>/dev/null || true
+fi
 check_result
 
 # Add instance IP address into /etc/ansible/hosts

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euox pipefail
 
+ARCH=$(uname -m)
+
 # Dumps details about the instance running the CI job.
 echo -e "\033[0;36m"
 cat << EOF
@@ -30,6 +32,7 @@ SSH_KEY=key/ostree_key
 SSH_KEY_PUB=$(cat "${SSH_KEY}".pub)
 EDGE_USER=core
 EDGE_USER_PASSWORD=foobar
+CONSOLE_LOG=/tmp/vm-console.log
 
 case "${ID}-${VERSION_ID}" in
     "fedora-43")
@@ -37,35 +40,30 @@ case "${ID}-${VERSION_ID}" in
         BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:43"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"
-        sudo dnf install -y rpmbuild rust-packaging
         ;;
     "fedora-44")
         OS_VARIANT="fedora-unknown"
         BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:44"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"
-        sudo dnf install -y rpmbuild rust-packaging
         ;;
     "fedora-45")
         OS_VARIANT="fedora-rawhide"
         BASE_IMAGE_URL="quay.io/fedora/fedora-bootc:rawhide"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"
-        sudo dnf install -y rpmbuild rust-packaging
         ;;
     "centos-10")
         OS_VARIANT="centos-stream9"
         BASE_IMAGE_URL="quay.io/centos-bootc/centos-bootc:stream10"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
-        sudo dnf install -y make rpm-build rust-toolset
         ;;
     "rhel-9.8")
         OS_VARIANT="rhel9-unknown"
         BASE_IMAGE_URL="registry.stage.redhat.io/rhel9/rhel-bootc:9.8"
         BIB_URL="registry.stage.redhat.io/rhel9/bootc-image-builder:9.8"
         BOOT_ARGS="uefi"
-        sudo dnf install -y make rpm-build rust-toolset
         sed -i "s/REPLACE_ME_HERE/${DOWNLOAD_NODE}/g" files/rhel-9-8.repo
         ;;
     "rhel-10.2")
@@ -73,7 +71,6 @@ case "${ID}-${VERSION_ID}" in
         BASE_IMAGE_URL="registry.stage.redhat.io/rhel10/rhel-bootc:10.2"
         BIB_URL="registry.stage.redhat.io/rhel10/bootc-image-builder:10.2"
         BOOT_ARGS="uefi"
-        sudo dnf install -y make rpm-build rust-toolset
         sed -i "s/REPLACE_ME_HERE/${DOWNLOAD_NODE}/g" files/rhel-10-2.repo
         ;;
     *)
@@ -112,7 +109,7 @@ wait_for_ssh_up () {
 ##
 ###########################################################
 greenprint "Installing required packages"
-sudo dnf install -y podman qemu-img firewalld qemu-kvm libvirt-client libvirt-daemon-kvm libvirt-daemon virt-install rpmdevtools ansible-core cargo lorax gobject-introspection
+sudo dnf install -y podman qemu-img firewalld qemu-kvm libvirt-client libvirt-daemon-kvm libvirt-daemon virt-install ansible-core lorax gobject-introspection
 ansible-galaxy collection install community.general
 
 # Start firewalld
@@ -174,17 +171,17 @@ fi
 
 ###########################################################
 ##
-## Build greenboot rpm packages
+## Copy test assets
 ##
 ###########################################################
-greenprint "Building greenboot packages"
-pushd .. && \
-make rpm
-cp rpmbuild/RPMS/x86_64/*.rpm tests/
-cp testing_assets/passing_script.sh tests/
-cp testing_assets/passing_binary tests/
-cp testing_assets/failing_script.sh tests/
-cp testing_assets/failing_binary tests/ && popd
+greenprint "Copying test assets"
+(
+    cd ..
+    cp testing_assets/passing_script.sh tests/
+    cp testing_assets/passing_binary tests/
+    cp testing_assets/failing_script.sh tests/
+    cp testing_assets/failing_binary tests/
+)
 
 ###########################################################
 ##
@@ -196,10 +193,9 @@ podman login quay.io -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD}
 podman login registry.stage.redhat.io -u ${STAGE_REDHAT_IO_USERNAME} -p ${STAGE_REDHAT_IO_TOKEN}
 tee Containerfile > /dev/null << EOF
 FROM ${BASE_IMAGE_URL}
-# Copy the local RPM files into the container
-COPY greenboot-*.rpm /tmp/
-RUN dnf install -y \
-    /tmp/greenboot-*.rpm && \
+RUN dnf install -y 'dnf-command(copr)' && \
+    dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUMBER} && \
+    dnf install -y greenboot greenboot-default-health-checks && \
     systemctl enable greenboot-healthcheck.service
 RUN sed -i "s/GREENBOOT_MAX_BOOT_ATTEMPTS=3/GREENBOOT_MAX_BOOT_ATTEMPTS=5/g" /etc/greenboot/greenboot.conf
 RUN sed -i 's#DISABLED_HEALTHCHECKS=()#DISABLED_HEALTHCHECKS=("01_repository_dns_check.sh" "not_exit.sh")#g' /etc/greenboot/greenboot.conf
@@ -216,8 +212,6 @@ COPY failing_script.sh /etc/greenboot/red.d
 
 COPY passing_binary /etc/greenboot/check/required.d/
 COPY failing_binary /etc/greenboot/check/wanted.d/
-# Clean up by removing the local RPMs if desired
-RUN rm -f /tmp/greenboot-*.rpm
 EOF
 
 if [[ "${ID}-${VERSION_ID}" == "rhel-9.8" ]]; then
@@ -232,7 +226,22 @@ COPY files/rhel-10-2.repo /etc/yum.repos.d/rhel-10-2.repo
 EOF
 fi
 
-podman build  --retry=5 --retry-delay=10s -t quay.io/${QUAY_USERNAME}/greenboot-bootc:${TEST_UUID} -f Containerfile .
+greenprint "Building container (retrying until Copr build is available)"
+build_success=false
+for attempt in $(seq 1 10); do
+    if podman build --retry=5 --retry-delay=10s -t quay.io/${QUAY_USERNAME}/greenboot-bootc:${TEST_UUID} -f Containerfile .; then
+        build_success=true
+        break
+    fi
+    greenprint "Container build attempt ${attempt}/10 failed, retrying in 60s..."
+    sleep 60
+done
+
+if [ "$build_success" = false ]; then
+    echo "Container build failed after 10 attempts."
+    exit 1
+fi
+
 greenprint "Pushing bootc container to quay.io"
 podman push quay.io/${QUAY_USERNAME}/greenboot-bootc:${TEST_UUID}
 
@@ -295,7 +304,8 @@ sudo virt-install  --name="${TEST_UUID}-uefi"\
                    --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --boot ${BOOT_ARGS} \
-                   --nographics \
+                   --graphics none \
+                   --serial file,path=${CONSOLE_LOG} \
                    --noautoconsole \
                    --wait=-1 \
                    --import \
@@ -314,6 +324,14 @@ for _ in $(seq 0 30); do
     fi
     sleep 10
 done
+
+if [[ $RESULTS != 1 ]]; then
+    greenprint "SSH failed on initial boot — collecting VM diagnostics"
+    sudo virsh domstate "${TEST_UUID}-uefi" || true
+    sudo virsh net-dhcp-leases integration || true
+    greenprint "VM console output (last 100 lines):"
+    sudo tail -100 ${CONSOLE_LOG} 2>/dev/null || true
+fi
 check_result
 
 ###########################################################
@@ -354,6 +372,14 @@ for _ in $(seq 0 30); do
     fi
     sleep 10
 done
+
+if [[ $RESULTS != 1 ]]; then
+    greenprint "SSH failed after upgrade — collecting VM diagnostics"
+    sudo virsh domstate "${TEST_UUID}-uefi" || true
+    sudo virsh net-dhcp-leases integration || true
+    greenprint "VM console output (last 100 lines):"
+    sudo tail -100 ${CONSOLE_LOG} 2>/dev/null || true
+fi
 check_result
 
 # Add instance IP address into /etc/ansible/hosts

--- a/tests/greenboot-ostree.sh
+++ b/tests/greenboot-ostree.sh
@@ -395,6 +395,7 @@ greenprint "Generate kickstart file"
 sudo tee "$KS_FILE" > /dev/null << STOPHERE
 text
 rootpw --lock --iscrypted locked
+user --name=${SSH_USER} --groups=wheel --iscrypted --password=\$6\$GRmb7S0p8vsYmXzH\$o0E020S.9JQGaHkszoog4ha4AQVs3sk8q0DvLjSMxoxHBKnB2FBXGQ/OkwZQfW/76ktHd0NX5nls2LPxPuUdl.
 network --bootproto=dhcp --device=link --activate --onboot=on
 zerombr
 clearpart --all --initlabel --disklabel=gpt

--- a/tests/greenboot-ostree.sh
+++ b/tests/greenboot-ostree.sh
@@ -82,6 +82,14 @@ sudo mkdir -p /etc/osbuild-composer/repositories
 
 # Set os-variant and boot location used by virt-install.
 case "${ID}-${VERSION_ID}" in
+    "fedora-"*)
+        OSTREE_REF="fedora/${VERSION_ID}/${ARCH}/iot"
+        OS_NAME="fedora-iot"
+        IMAGE_TYPE=iot-commit
+        OS_VARIANT="fedora-unknown"
+        BOOT_LOCATION="https://dl.fedoraproject.org/pub/fedora/linux/releases/${VERSION_ID}/Everything/${ARCH}/os/"
+        COPR_REPO_URL="https://download.copr.fedorainfracloud.org/results/packit/fedora-iot-greenboot-rs-${PR_NUMBER}/fedora-${VERSION_ID}-${ARCH}/"
+        ;;
     "centos-9")
         OSTREE_REF="centos/9/${ARCH}/edge"
         OS_VARIANT="centos-stream9"
@@ -93,7 +101,6 @@ case "${ID}-${VERSION_ID}" in
     "rhel-9.8")
         OSTREE_REF="rhel/9/${ARCH}/edge"
         OS_VARIANT="rhel9-unknown"
-        BOOT_ARGS="uefi"
         BOOT_LOCATION="http://${DOWNLOAD_NODE}/rhel-9/nightly/RHEL-9/latest-RHEL-9.8.0/compose/BaseOS/${ARCH}/os/"
         COPR_REPO_URL="https://download.copr.fedorainfracloud.org/results/packit/fedora-iot-greenboot-rs-${PR_NUMBER}/centos-stream-9-${ARCH}/"
         sed "s/REPLACE_ME_HERE/${DOWNLOAD_NODE}/g" files/rhel-9-8-0.json | sudo tee /etc/osbuild-composer/repositories/rhel-98.json > /dev/null;;

--- a/tests/greenboot-ostree.sh
+++ b/tests/greenboot-ostree.sh
@@ -397,7 +397,7 @@ text
 rootpw --lock --iscrypted locked
 network --bootproto=dhcp --device=link --activate --onboot=on
 zerombr
-clearpart --all --initlabel --disklabel=msdos
+clearpart --all --initlabel --disklabel=gpt
 autopart --nohome --noswap --type=plain
 ostreesetup --nogpg --osname=${OS_NAME} --remote=${OS_NAME} --url=${PROD_REPO_URL} --ref=${OSTREE_REF}
 poweroff

--- a/tests/greenboot-ostree.sh
+++ b/tests/greenboot-ostree.sh
@@ -44,6 +44,7 @@ SSH_USER="admin"
 OS_NAME="rhel-edge"
 IMAGE_TYPE=edge-commit
 PROD_REPO_URL=http://192.168.100.1/repo
+CONSOLE_LOG=/tmp/vm-console.log
 
 # Set up temporary files.
 TEMPDIR=$(mktemp -d)
@@ -64,7 +65,7 @@ sudo localectl set-locale LANG=en_US.UTF-8
 
 # Install required packages
 greenprint "Install required packages"
-sudo dnf install -y --nogpgcheck httpd osbuild osbuild-composer composer-cli ansible-core createrepo_c podman qemu-img firewalld qemu-kvm libvirt-client libvirt-daemon-kvm libvirt-daemon virt-install rpmdevtools cargo lorax gobject-introspection make rpm-build rust-toolset
+sudo dnf install -y --nogpgcheck httpd osbuild osbuild-composer composer-cli ansible-core podman qemu-img firewalld qemu-kvm libvirt-client libvirt-daemon-kvm libvirt-daemon virt-install lorax gobject-introspection
 
 # Avoid collection installation filed sometime
 for _ in $(seq 0 30); do
@@ -86,27 +87,45 @@ case "${ID}-${VERSION_ID}" in
         OS_VARIANT="centos-stream9"
         BOOT_ARGS="uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
         CURRENT_COMPOSE_CS9=$(curl -s "https://composes.stream.centos.org/production/" | grep -ioE ">CentOS-Stream-9-.*/<" | tr -d '>/<' | tail -1)
-        BOOT_LOCATION="https://composes.stream.centos.org/production/${CURRENT_COMPOSE_CS9}/compose/BaseOS/x86_64/os/"
+        BOOT_LOCATION="https://composes.stream.centos.org/production/${CURRENT_COMPOSE_CS9}/compose/BaseOS/${ARCH}/os/"
+        COPR_REPO_URL="https://download.copr.fedorainfracloud.org/results/packit/fedora-iot-greenboot-rs-${PR_NUMBER}/centos-stream-9-${ARCH}/"
         sudo cp files/centos-stream-9.json /etc/osbuild-composer/repositories/centos-9.json;;
     "rhel-9.8")
         OSTREE_REF="rhel/9/${ARCH}/edge"
         OS_VARIANT="rhel9-unknown"
         BOOT_ARGS="uefi"
-        BOOT_LOCATION="http://${DOWNLOAD_NODE}/rhel-9/nightly/RHEL-9/latest-RHEL-9.8.0/compose/BaseOS/x86_64/os/"
+        BOOT_LOCATION="http://${DOWNLOAD_NODE}/rhel-9/nightly/RHEL-9/latest-RHEL-9.8.0/compose/BaseOS/${ARCH}/os/"
+        COPR_REPO_URL="https://download.copr.fedorainfracloud.org/results/packit/fedora-iot-greenboot-rs-${PR_NUMBER}/centos-stream-9-${ARCH}/"
         sed "s/REPLACE_ME_HERE/${DOWNLOAD_NODE}/g" files/rhel-9-8-0.json | sudo tee /etc/osbuild-composer/repositories/rhel-98.json > /dev/null;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;
 esac
 
-# Build greenboot RPMs
-greenprint "Building greenboot packages"
-pushd .. && \
-make rpm
-mkdir -p /var/www/html/packages
-cp rpmbuild/RPMS/x86_64/*.rpm /var/www/html/packages/
-sudo createrepo_c /var/www/html/packages
-sudo restorecon -Rv /var/www/html/packages && popd
+# Add Copr repo as osbuild-composer source for greenboot PR builds
+greenprint "Adding Copr source for greenboot PR #${PR_NUMBER}"
+sudo tee /tmp/greenboot-copr.toml > /dev/null << EOF
+id = "greenboot-copr"
+name = "Packit Copr greenboot PR build"
+type = "yum-baseurl"
+url = "${COPR_REPO_URL}"
+check_gpg = false
+check_ssl = false
+EOF
+copr_added=false
+for _ in $(seq 0 30); do
+    if sudo composer-cli sources add /tmp/greenboot-copr.toml; then
+        copr_added=true
+        break
+    fi
+    greenprint "Copr source not ready yet, retrying in 30s..."
+    sleep 30
+done
+
+if [ "$copr_added" = false ]; then
+    echo "Failed to add Copr source after 30 attempts."
+    exit 1
+fi
 
 # Check ostree_key permissions
 KEY_PERMISSION_PRE=$(stat -L -c "%a %G %U" key/ostree_key | grep -oP '\d+' | head -n 1)
@@ -326,7 +345,7 @@ name = "sssd"
 version = "*"
 
 [customizations.services]
-enabled = ["greenboot-set-rollback-trigger.service", "greenboot-success.target"]
+enabled = ["greenboot-healthcheck.service", "greenboot-set-rollback-trigger.service", "greenboot-success.target"]
 
 [[customizations.user]]
 name = "${SSH_USER}"
@@ -391,7 +410,8 @@ sudo virt-install  --name="${IMAGE_KEY}"\
                    --os-variant ${OS_VARIANT} \
                    --boot ${BOOT_ARGS} \
                    --location "${BOOT_LOCATION}" \
-                   --nographics \
+                   --graphics none \
+                   --serial file,path=${CONSOLE_LOG} \
                    --noautoconsole \
                    --wait=-1 \
                    --noreboot
@@ -410,6 +430,15 @@ for _ in $(seq 0 30); do
     fi
     sleep 10
 done
+
+if [[ $RESULTS != 1 ]]; then
+    greenprint "SSH failed on initial boot — collecting VM diagnostics"
+    sudo virsh domstate "${IMAGE_KEY}" || true
+    sudo virsh net-dhcp-leases integration || true
+    greenprint "VM console output (last 100 lines):"
+    sudo tail -100 ${CONSOLE_LOG} 2>/dev/null || true
+fi
+check_result
 
 greenprint "🛃 Copying binary and script files to edge vm"
 

--- a/tests/greenboot-ostree.sh
+++ b/tests/greenboot-ostree.sh
@@ -266,10 +266,13 @@ build_image() {
     while true; do
         sudo composer-cli --json compose info "${COMPOSE_ID}" | tee "$COMPOSE_INFO" > /dev/null
 
-        COMPOSE_STATUS=$(jq -r '.[0].body.queue_status' "$COMPOSE_INFO")
+        # Handle both v1 (CentOS/RHEL) and v2 (Fedora) API formats
+        COMPOSE_STATUS=$(jq -r '.[].body | (.queue_status // .image_status?.status) | select(. != null)' "$COMPOSE_INFO")
 
         # Is the compose finished?
-        if [[ $COMPOSE_STATUS != RUNNING ]] && [[ $COMPOSE_STATUS != WAITING ]]; then
+        # v1: RUNNING/WAITING/FINISHED/FAILED  v2: building/pending/success/failure
+        if [[ $COMPOSE_STATUS != RUNNING ]] && [[ $COMPOSE_STATUS != WAITING ]] \
+            && [[ $COMPOSE_STATUS != building ]] && [[ $COMPOSE_STATUS != pending ]]; then
             break
         fi
 
@@ -283,7 +286,7 @@ build_image() {
     get_compose_metadata "$COMPOSE_ID"
 
     # Did the compose finish with success?
-    if [[ $COMPOSE_STATUS != FINISHED ]]; then
+    if [[ $COMPOSE_STATUS != FINISHED ]] && [[ $COMPOSE_STATUS != success ]]; then
         echo "Something went wrong with the compose. 😢"
         exit 1
     fi


### PR DESCRIPTION
## Summary
- Switch all test scripts (bootc, ostree) from local `make rpm` to Packit Copr PR builds
- Remove build dependencies (rust-toolset, createrepo_c, rpmdevtools, cargo, etc.) from test scripts
- Fix Packit release_suffix so PR builds have unique NVR and are installable
- Pass PR_NUMBER to all testing-farm CI jobs in both workflow files
- Add Fedora support to ostree test script (iot-commit image type, fedora-iot osname)
- Fix osbuild-composer v2 API compatibility for Fedora (different JSON status format)
- Fix ostree kickstart for UEFI (GPT partitioning, explicit user creation)
- Use arch variable in BOOT_LOCATION URLs for aarch64 support
