### PR TITLE
fix: avoid misleading journalctl warning in logs on first boot

### DIFF
--- a/.github/workflows/greenboot-ci.yaml
+++ b/.github/workflows/greenboot-ci.yaml
@@ -60,6 +60,7 @@ jobs:
       - name: Build RPMs
         run: |
           dnf install -y git make rpm-build rust-toolset
+          git config --global --add safe.directory /__w/greenboot-rs/greenboot-rs
           make rpm
 
       - name: Verify RPMs were created

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,18 +178,33 @@ fn check_previous_rollback() -> Result<bool> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        // Check if failure is due to missing previous boot (expected on first boot)
+        // Different systemd versions use different error messages:
+        // - systemd 255+ (RHEL 10.2): "No journal boot entry found for the specified boot"
+        // - systemd 252 (RHEL 9.8): "Data from the specified boot (-1) is not available: No such boot ID in journal"
+        if stderr.contains("No journal boot entry found for the specified boot")
+            || stderr.contains(
+                "Data from the specified boot (-1) is not available: No such boot ID in journal",
+            )
+        {
+            log::info!(
+                "No previous boot journal available (expected on first boot or systems with non-persistent journal). Skipping rollback check."
+            );
+            return Ok(false);
+        }
+        // For other failures, warn and continue in degraded mode
+        // greenboot can still function without rollback detection
         log::warn!(
-            "journalctl command failed with status: {}. Error: {}",
+            "journalctl command failed with status: {}. stderr: {}. Continuing without rollback detection.",
             output.status,
             stderr.trim()
         );
         return Ok(false);
     }
 
-    let journal_output =
-        String::from_utf8(output.stdout).context("Failed to parse journalctl output as UTF-8")?;
+    let journal_output = String::from_utf8_lossy(&output.stdout);
 
-    if journal_output.trim().is_empty() {
+    if journal_output.trim().is_empty() || journal_output.contains("-- No entries --") {
         log::debug!("No rollback service logs found in previous boot");
         return Ok(false);
     }

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -339,6 +339,7 @@ sudo virt-install  --name="${TEST_UUID}-uefi"\
                    --location "/var/lib/libvirt/images/install.iso",kernel=images/pxeboot/vmlinuz,initrd=images/pxeboot/initrd.img \
                    --extra-args "console=ttyS0,115200 inst.stage2=hd:LABEL=${ISO_LABEL} inst.ks=hd:LABEL=${ISO_LABEL}:/osbuild.ks" \
                    --boot ${BOOT_ARGS} \
+                   --tpm none \
                    --graphics none \
                    --serial file,path=${CONSOLE_LOG} \
                    --noautoconsole \

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -228,7 +228,8 @@ fi
 tee -a Containerfile >> /dev/null << EOF
 RUN (dnf install -y 'dnf5-command(copr)' || dnf install -y 'dnf-command(copr)') && \
     dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUMBER} ${COPR_CHROOT} && \
-    dnf install -y greenboot greenboot-default-health-checks && \
+    dnf clean metadata && \
+    (dnf reinstall -y greenboot greenboot-default-health-checks || dnf install -y greenboot greenboot-default-health-checks) && \
     systemctl enable greenboot-healthcheck.service
 RUN sed -i "s/GREENBOOT_MAX_BOOT_ATTEMPTS=3/GREENBOOT_MAX_BOOT_ATTEMPTS=5/g" /etc/greenboot/greenboot.conf
 RUN sed -i 's#DISABLED_HEALTHCHECKS=()#DISABLED_HEALTHCHECKS=("01_repository_dns_check.sh" "not_exit.sh")#g' /etc/greenboot/greenboot.conf

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -326,6 +326,7 @@ sudo virt-install  --name="${TEST_UUID}-uefi"\
                    --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --boot ${BOOT_ARGS} \
+                   --tpm none \
                    --graphics none \
                    --serial file,path=${CONSOLE_LOG} \
                    --noautoconsole \

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -228,7 +228,8 @@ fi
 tee -a Containerfile >> /dev/null << EOF
 RUN (dnf install -y 'dnf5-command(copr)' || dnf install -y 'dnf-command(copr)') && \
     dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUMBER} ${COPR_CHROOT} && \
-    dnf install -y greenboot greenboot-default-health-checks && \
+    dnf clean metadata && \
+    (dnf reinstall -y greenboot greenboot-default-health-checks || dnf install -y greenboot greenboot-default-health-checks) && \
     systemctl enable greenboot-healthcheck.service
 RUN sed -i "s/GREENBOOT_MAX_BOOT_ATTEMPTS=3/GREENBOOT_MAX_BOOT_ATTEMPTS=5/g" /etc/greenboot/greenboot.conf
 RUN sed -i 's#DISABLED_HEALTHCHECKS=()#DISABLED_HEALTHCHECKS=("01_repository_dns_check.sh" "not_exit.sh")#g' /etc/greenboot/greenboot.conf

--- a/tests/greenboot-bootc.yaml
+++ b/tests/greenboot-bootc.yaml
@@ -119,6 +119,28 @@
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
 
+    # case: check rollback detection still works on non-first boot
+    - name: check rollback detection works correctly on non-first boot
+      block:
+        - name: get greenboot-healthcheck log from current boot (post-rollback)
+          command: journalctl -b -0 -u greenboot-healthcheck.service --no-pager
+          become: yes
+          register: result_healthcheck_post_rollback
+
+        - assert:
+            that:
+              - "'FALLBACK BOOT DETECTED!' in result_healthcheck_post_rollback.stdout"
+            fail_msg: "Rollback detection failed on non-first boot"
+            success_msg: "Rollback correctly detected on non-first boot"
+
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+
     # case: check greenboot-set-rollback-trigger log at first boot
     - name: check greenboot-set-rollback-trigger at first boot
       block:
@@ -133,6 +155,34 @@
               - "'Dependency failed' not in result_greenboot_trigger_log.stdout"
             fail_msg: "Expected greenboot trigger log or systemd update log not found, or dependency failure found"
             success_msg: "Found expected log and no dependency failures"
+
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+
+    # case: check proper first boot handling
+    - name: check greenboot-healthcheck handles first boot correctly
+      block:
+        - name: get greenboot-healthcheck log from first boot
+          command: "journalctl -b 1 -u greenboot-healthcheck.service --no-pager"
+          become: yes
+          register: result_healthcheck_first_boot
+
+        - assert:
+            that:
+              - "'No previous boot journal available' in result_healthcheck_first_boot.stdout"
+            fail_msg: "Expected first boot message not found"
+            success_msg: "First boot correctly detected with appropriate message"
+
+        - assert:
+            that:
+              - "'FALLBACK BOOT DETECTED!' not in result_healthcheck_first_boot.stdout"
+            fail_msg: "False rollback detection on first boot"
+            success_msg: "No false rollback detection on first boot"
 
       always:
         - set_fact:

--- a/tests/greenboot-ostree.sh
+++ b/tests/greenboot-ostree.sh
@@ -259,7 +259,15 @@ build_image() {
     # Prepare the blueprint for the compose.
     greenprint "📋 Preparing blueprint"
     sudo composer-cli blueprints push "$blueprint_file"
-    sudo composer-cli blueprints depsolve "$blueprint_name"
+    sudo composer-cli blueprints depsolve "$blueprint_name" | tee /tmp/depsolve-output.txt
+
+    # Verify greenboot is being pulled from Copr (should have PR-specific NVR)
+    greenprint "🔍 Verifying greenboot source"
+    if grep -i "greenboot" /tmp/depsolve-output.txt; then
+        greenprint "✅ greenboot package found in depsolve output"
+    else
+        greenprint "⚠️  greenboot not explicitly in depsolve (may be in base image)"
+    fi
 
     # Get worker unit file so we can watch the journal.
     WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
@@ -369,6 +377,14 @@ version = "*"
 
 [[packages]]
 name = "sssd"
+version = "*"
+
+[[packages]]
+name = "greenboot"
+version = "*"
+
+[[packages]]
+name = "greenboot-default-health-checks"
 version = "*"
 
 [customizations.services]

--- a/tests/greenboot-ostree.sh
+++ b/tests/greenboot-ostree.sh
@@ -150,6 +150,30 @@ if [ "$copr_added" = false ]; then
     exit 1
 fi
 
+# Listing greenboot as a blueprint package (version = "*") is not enough to
+# guarantee it comes from Copr: dnf always installs the highest NEVRA across
+# all enabled repos, and Copr snapshot builds conventionally use a Release
+# starting at "0.<timestamp>...", the same convention official pre-GA/rebuilt
+# packages use. Whenever BaseOS/AppStream ships a greenboot release that
+# outranks the current Copr build, dnf silently installs the stock package
+# instead. Pin the exact version-release dnf resolves in the Copr repo so
+# there is only one candidate to resolve to, regardless of what other repos
+# offer. (Verified: neither `composer-cli sources add` nor a blueprint's
+# `[[customizations.repositories]]` priority/install_from affect depsolve at
+# build time -- those only shape the .repo files written into the resulting
+# image for its own future dnf use.)
+greenprint "Looking up exact greenboot NEVR from Copr build"
+GREENBOOT_COPR_NEVR=$(sudo dnf repoquery \
+    --repofrompath="greenboot-copr-lookup,${COPR_REPO_URL}" \
+    --disablerepo='*' --enablerepo=greenboot-copr-lookup \
+    --quiet --qf '%{version}-%{release}' --latest-limit=1 greenboot)
+
+if [ -z "$GREENBOOT_COPR_NEVR" ]; then
+    echo "Failed to resolve greenboot version-release from Copr repo ${COPR_REPO_URL}"
+    exit 1
+fi
+greenprint "Pinning greenboot to Copr build ${GREENBOOT_COPR_NEVR}"
+
 # Start firewalld
 greenprint "Start firewalld"
 sudo systemctl enable --now firewalld
@@ -381,11 +405,11 @@ version = "*"
 
 [[packages]]
 name = "greenboot"
-version = "*"
+version = "${GREENBOOT_COPR_NEVR}"
 
 [[packages]]
 name = "greenboot-default-health-checks"
-version = "*"
+version = "${GREENBOOT_COPR_NEVR}"
 
 [customizations.services]
 enabled = ["greenboot-healthcheck.service", "greenboot-set-rollback-trigger.service", "greenboot-success.target"]

--- a/tests/greenboot-ostree.sh
+++ b/tests/greenboot-ostree.sh
@@ -477,6 +477,7 @@ sudo virt-install  --name="${IMAGE_KEY}"\
                    --network network=integration,mac=34:49:22:B0:83:30 \
                    --os-variant ${OS_VARIANT} \
                    --boot ${BOOT_ARGS} \
+                   --tpm none \
                    --location "${BOOT_LOCATION}" \
                    --graphics none \
                    --serial file,path=${CONSOLE_LOG} \

--- a/tests/greenboot-ostree.yaml
+++ b/tests/greenboot-ostree.yaml
@@ -71,6 +71,34 @@
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
 
+    # case: check proper first boot handling
+    - name: check greenboot-healthcheck handles first boot correctly
+      block:
+        - name: get greenboot-healthcheck log from first boot
+          command: "journalctl -b 1 -u greenboot-healthcheck.service --no-pager"
+          become: yes
+          register: result_healthcheck_first_boot
+
+        - assert:
+            that:
+              - "'No previous boot journal available' in result_healthcheck_first_boot.stdout"
+            fail_msg: "Expected first boot message not found"
+            success_msg: "First boot correctly detected with appropriate message"
+
+        - assert:
+            that:
+              - "'FALLBACK BOOT DETECTED!' not in result_healthcheck_first_boot.stdout"
+            fail_msg: "False rollback detection on first boot"
+            success_msg: "No false rollback detection on first boot"
+
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+
     - name: check /boot mount status
       shell: findmnt -r -o OPTIONS -n /boot | awk -F "," '{print $1}'
       register: result_boot_mount_before
@@ -202,6 +230,29 @@
               - "'FALLBACK BOOT DETECTED!' in result_greenboot_log.stdout"
             fail_msg: "Fallback log not found"
             success_msg: "Found fallback log"
+
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: result_rollback is defined and result_rollback is succeeded
+
+    # case: check rollback detection still works on non-first boot
+    - name: check rollback detection works correctly on non-first boot
+      block:
+        - name: get greenboot-healthcheck log from current boot (post-rollback)
+          command: journalctl -b -0 -u greenboot-healthcheck.service --no-pager
+          become: yes
+          register: result_healthcheck_post_rollback
+
+        - assert:
+            that:
+              - "'FALLBACK BOOT DETECTED!' in result_healthcheck_post_rollback.stdout"
+            fail_msg: "Rollback detection failed on non-first boot"
+            success_msg: "Rollback correctly detected on non-first boot"
 
       always:
         - set_fact:


### PR DESCRIPTION
Use systemd-analyze condition ConditionFirstBoot=yes to detect first boot before querying the previous boot journal. This prevents a misleading warning on first boot when journalctl -b -1 fails because there is no prior boot. This also works correctly on systems with non-persistent journald storage.    