### PR TITLE
fix(tests): ansible deprecation fix and CI improvements

### DIFF
--- a/.github/workflows/comment-ci.yaml
+++ b/.github/workflows/comment-ci.yaml
@@ -48,6 +48,9 @@ jobs:
     container:
       image: quay.io/centos/centos:stream9
     steps:
+      - name: Install git for checkout
+        run: dnf install -y git
+
       - name: Checkout PR code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/greenboot-ci.yaml
+++ b/.github/workflows/greenboot-ci.yaml
@@ -48,6 +48,9 @@ jobs:
     container:
       image: quay.io/centos/centos:stream9
     steps:
+      - name: Install git for checkout
+        run: dnf install -y git
+
       - name: Checkout PR code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,11 @@ vendor:
 	[ -z "$$vendor_filterer_cmd" ] || rm -f $${vendor_filterer_cmd}; \
 	. /etc/os-release; \
 	if [[ "$$ID" = "fedora" ]] || [[ "$$ID" = "centos" ]]; then \
-		sudo dnf install -y pkgconf-pkg-config openssl-devel; \
+		if [ "$$(id -u)" -eq 0 ]; then \
+			dnf install -y pkgconf-pkg-config openssl-devel; \
+		else \
+			sudo dnf install -y pkgconf-pkg-config openssl-devel; \
+		fi; \
 	fi; \
 	cargo install --quiet cargo-vendor-filterer@0.5.16; \
 	for platform in $(PLATFORMS); do  \

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -330,7 +330,7 @@ ISO_LABEL=$(blkid -o value -s LABEL /var/lib/libvirt/images/install.iso)
 greenprint "ISO label: ${ISO_LABEL}"
 sudo virt-install  --name="${TEST_UUID}-uefi"\
                    --disk path="${LIBVIRT_IMAGE_PATH_UEFI}",format=qcow2 \
-                   --ram 3072 \
+                   --ram 8192 \
                    --vcpus 2 \
                    --network network=integration,mac=34:49:22:B0:83:30 \
                    --os-type linux \

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -319,7 +319,7 @@ sudo restorecon -Rv /var/lib/libvirt/images/
 
 sudo virt-install  --name="${TEST_UUID}-uefi"\
                    --disk path="${LIBVIRT_IMAGE_PATH_UEFI}",format=qcow2 \
-                   --ram 3072 \
+                   --ram 8192 \
                    --vcpus 2 \
                    --network network=integration,mac=34:49:22:B0:83:30 \
                    --os-type linux \

--- a/tests/greenboot-bootc.yaml
+++ b/tests/greenboot-bootc.yaml
@@ -8,7 +8,7 @@
 
   tasks:
     # current target host's IP address
-    - debug: var=ansible_all_ipv4_addresses
+    - debug: var=ansible_facts['all_ipv4_addresses']
     - debug: var=ansible_facts['distribution_version']
     - debug: var=ansible_facts['distribution']
     - debug: var=ansible_facts['architecture']

--- a/tests/greenboot-fedora-iot-raw.sh
+++ b/tests/greenboot-fedora-iot-raw.sh
@@ -249,7 +249,7 @@ sudo kpartx -dv "${LIBVIRT_IMAGE_PATH}"
 greenprint "🚀 Installing VM from raw image"
 sudo virt-install  --name="${IMAGE_KEY}"\
                    --disk path="${LIBVIRT_IMAGE_PATH}",format=raw \
-                   --ram 4096 \
+                   --ram 8192 \
                    --vcpus 2 \
                    --network network=integration,mac=34:49:22:B0:83:30 \
                    --os-variant ${OS_VARIANT} \

--- a/tests/greenboot-ostree.sh
+++ b/tests/greenboot-ostree.sh
@@ -432,7 +432,7 @@ sudo virt-install  --name="${IMAGE_KEY}"\
                    --initrd-inject="${KS_FILE}" \
                    --extra-args="inst.ks=file:/ks.cfg console=ttyS0,115200" \
                    --disk path="${LIBVIRT_IMAGE_PATH}",format=qcow2 \
-                   --ram 4096 \
+                   --ram 8192 \
                    --vcpus 2 \
                    --network network=integration,mac=34:49:22:B0:83:30 \
                    --os-variant ${OS_VARIANT} \

--- a/tests/greenboot-ostree.yaml
+++ b/tests/greenboot-ostree.yaml
@@ -7,7 +7,7 @@
 
   tasks:
     # current target host's IP address
-    - debug: var=ansible_all_ipv4_addresses
+    - debug: var=ansible_facts['all_ipv4_addresses']
     - debug: var=ansible_facts['distribution_version']
     - debug: var=ansible_facts['distribution']
     - debug: var=ansible_facts['architecture']
@@ -146,7 +146,7 @@
 
         - name: waits until instance is reachable
           wait_for:
-            host: "{{ ansible_all_ipv4_addresses[0] }}"
+            host: "{{ ansible_facts['all_ipv4_addresses'][0] }}"
             port: 22
             search_regex: OpenSSH
             delay: 10

--- a/tmt/plans/greenboot-test.fmf
+++ b/tmt/plans/greenboot-test.fmf
@@ -9,8 +9,10 @@ provision:
     virtualization:
       is-supported: true
     cpu:
-      processors: ">= 2"
-    memory: ">= 6 GB"
+      processors: ">= 4"
+    memory: ">= 16 GB"
+    disk:
+      - size: ">= 40 GB"
 
 /bootc-qcow2:
   summary: Test greenboot with bootc qcow2 image


### PR DESCRIPTION
## Summary

- Replace deprecated `ansible_all_ipv4_addresses` with `ansible_facts['all_ipv4_addresses']` before `INJECT_FACTS_AS_VARS` defaults to `False` in ansible-core 2.24
- Skip `sudo` when running as root in Makefile vendor target (fixes make-rpm in CS9 container)
- Install git before `actions/checkout` in CS9 container (fixes `git archive` failure)
- Increase Testing Farm hardware requirements (4 CPUs, 16 GB RAM, 40 GB disk) and VM RAM to 8 GB for improved nested virt reliability

Assisted-by: Claude (claude-opus-4-6)