### PR TITLE
test: drop vTPM from virt-install VMs

### DIFF
--- a/tests/greenboot-fedora-iot-raw.sh
+++ b/tests/greenboot-fedora-iot-raw.sh
@@ -254,6 +254,7 @@ sudo virt-install  --name="${IMAGE_KEY}"\
                    --network network=integration,mac=34:49:22:B0:83:30 \
                    --os-variant ${OS_VARIANT} \
                    --boot ${BOOT_ARGS} \
+                   --tpm none \
                    --graphics none \
                    --serial file,path=${CONSOLE_LOG} \
                    --noautoconsole \


### PR DESCRIPTION
greenboot tests don't exercise TPM or measured-boot functionality, but virt-install's os-variant device policy auto-adds a vTPM device for UEFI boots on modern os-variants. A Fedora 44 SELinux userspace regression (3.10->3.11) currently breaks swtpm-selinux's CIL policy compilation (RHBZ#2511086), leaving /usr/bin/swtpm mislabeled and unable to exec under libvirt, which fails every UEFI VM boot in CI. Since the vTPM was never needed, explicitly disable it instead of waiting for the swtpm fix to reach stable Fedora 44 repos.

Suggested-by: Klára Nečasová <knecasov@redhat.com>
🤖 Assisted-by: OpenCode (Claude Sonnet 5)