### PR TITLE
test: propagate Copr NEVR pinning (eb7d75c) to bootc/fedora-iot-raw scripts

### DIFF
--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -302,6 +302,18 @@ EOF
         ;;
 esac
 
+# Listing greenboot/greenboot-default-health-checks by name isn't enough to
+# guarantee the Copr build gets picked: dnf always resolves to the highest
+# NEVRA across all enabled repos, and Copr snapshot builds conventionally use
+# a Release starting at "0.<timestamp>...", the same convention official
+# pre-GA/rebuilt packages use. Whenever a base repo ships a greenboot release
+# that outranks the current Copr build, an unscoped reinstall/install would
+# silently fall back to the stock package instead. Restrict resolution to
+# just the just-enabled Copr repo so there is only one candidate regardless
+# of what other repos offer (see commit eb7d75c, which fixed the same class
+# of bug for the ostree/osbuild-composer flow).
+GREENBOOT_COPR_REPO_ID="copr:copr.fedorainfracloud.org:packit:fedora-iot-greenboot-rs-${PR_NUMBER}"
+
 if [[ "${USE_COMPOSE_RPMS}" == true && -n "${GREENBOOT_PACKAGES_URL}" ]]; then
     tee -a Containerfile > /dev/null << EOF
 COPY greenboot-*.rpm /tmp/
@@ -314,7 +326,7 @@ else
 RUN (dnf install -y 'dnf5-command(copr)' || dnf install -y 'dnf-command(copr)') && \
     dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUMBER} ${COPR_CHROOT} && \
     dnf clean metadata && \
-    (dnf reinstall -y greenboot greenboot-default-health-checks || dnf install -y greenboot greenboot-default-health-checks) && \
+    (dnf reinstall -y --from-repo='${GREENBOOT_COPR_REPO_ID}' greenboot greenboot-default-health-checks || dnf install -y --from-repo='${GREENBOOT_COPR_REPO_ID}' greenboot greenboot-default-health-checks) && \
     systemctl enable greenboot-healthcheck.service
 EOF
 fi

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -326,7 +326,9 @@ else
 RUN (dnf install -y 'dnf5-command(copr)' || dnf install -y 'dnf-command(copr)') && \
     dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUMBER} ${COPR_CHROOT} && \
     dnf clean metadata && \
-    (dnf reinstall -y --from-repo='${GREENBOOT_COPR_REPO_ID}' greenboot greenboot-default-health-checks || dnf install -y --from-repo='${GREENBOOT_COPR_REPO_ID}' greenboot greenboot-default-health-checks) && \
+    dnf download --from-repo='${GREENBOOT_COPR_REPO_ID}' --destdir /tmp/copr-rpms greenboot greenboot-default-health-checks && \
+    dnf install -y /tmp/copr-rpms/*.rpm && \
+    rm -rf /tmp/copr-rpms && \
     systemctl enable greenboot-healthcheck.service
 EOF
 fi

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -302,6 +302,18 @@ EOF
         ;;
 esac
 
+# Listing greenboot/greenboot-default-health-checks by name isn't enough to
+# guarantee the Copr build gets picked: dnf always resolves to the highest
+# NEVRA across all enabled repos, and Copr snapshot builds conventionally use
+# a Release starting at "0.<timestamp>...", the same convention official
+# pre-GA/rebuilt packages use. Whenever a base repo ships a greenboot release
+# that outranks the current Copr build, an unscoped reinstall/install would
+# silently fall back to the stock package instead. Restrict resolution to
+# just the just-enabled Copr repo so there is only one candidate regardless
+# of what other repos offer (see commit eb7d75c, which fixed the same class
+# of bug for the ostree/osbuild-composer flow).
+GREENBOOT_COPR_REPO_ID="copr:copr.fedorainfracloud.org:packit:fedora-iot-greenboot-rs-${PR_NUMBER}"
+
 if [[ "${USE_COMPOSE_RPMS}" == true && -n "${GREENBOOT_PACKAGES_URL}" ]]; then
     tee -a Containerfile > /dev/null << EOF
 COPY greenboot-*.rpm /tmp/
@@ -314,7 +326,7 @@ else
 RUN (dnf install -y 'dnf5-command(copr)' || dnf install -y 'dnf-command(copr)') && \
     dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUMBER} ${COPR_CHROOT} && \
     dnf clean metadata && \
-    (dnf reinstall -y greenboot greenboot-default-health-checks || dnf install -y greenboot greenboot-default-health-checks) && \
+    (dnf reinstall -y --from-repo='${GREENBOOT_COPR_REPO_ID}' greenboot greenboot-default-health-checks || dnf install -y --from-repo='${GREENBOOT_COPR_REPO_ID}' greenboot greenboot-default-health-checks) && \
     systemctl enable greenboot-healthcheck.service
 EOF
 fi

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -326,7 +326,9 @@ else
 RUN (dnf install -y 'dnf5-command(copr)' || dnf install -y 'dnf-command(copr)') && \
     dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUMBER} ${COPR_CHROOT} && \
     dnf clean metadata && \
-    (dnf reinstall -y --from-repo='${GREENBOOT_COPR_REPO_ID}' greenboot greenboot-default-health-checks || dnf install -y --from-repo='${GREENBOOT_COPR_REPO_ID}' greenboot greenboot-default-health-checks) && \
+    dnf download --from-repo='${GREENBOOT_COPR_REPO_ID}' --destdir /tmp/copr-rpms greenboot greenboot-default-health-checks && \
+    dnf install -y /tmp/copr-rpms/*.rpm && \
+    rm -rf /tmp/copr-rpms && \
     systemctl enable greenboot-healthcheck.service
 EOF
 fi

--- a/tests/greenboot-fedora-iot-raw.sh
+++ b/tests/greenboot-fedora-iot-raw.sh
@@ -308,9 +308,21 @@ if [[ $copr_result != 0 ]]; then
     exit 1
 fi
 
+# Listing greenboot/greenboot-default-health-checks by name isn't enough to
+# guarantee the Copr build gets picked: dnf always resolves to the highest
+# NEVRA across all enabled repos, and Copr snapshot builds conventionally use
+# a Release starting at "0.<timestamp>...", the same convention official
+# pre-GA/rebuilt packages use. Whenever BaseOS/AppStream/Fedora ships a
+# greenboot release that outranks the current Copr build, an unscoped
+# download would silently fetch the stock package instead. Restrict
+# resolution to just the just-enabled Copr repo so there is only one
+# candidate regardless of what other repos offer (see commit eb7d75c, which
+# fixed the same class of bug for the ostree/osbuild-composer flow).
+GREENBOOT_COPR_REPO_ID="copr:copr.fedorainfracloud.org:packit:fedora-iot-greenboot-rs-${PR_NUMBER}"
+
 greenprint "📦 Downloading greenboot RPMs from Copr"
 ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "${SSH_USER}@${GUEST_ADDRESS}" \
-    "dnf download --destdir /tmp/greenboot-rpms greenboot greenboot-default-health-checks"
+    "dnf download --from-repo='${GREENBOOT_COPR_REPO_ID}' --destdir /tmp/greenboot-rpms greenboot greenboot-default-health-checks"
 
 greenprint "📦 Replacing greenboot packages with PR build"
 ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "${SSH_USER}@${GUEST_ADDRESS}" \


### PR DESCRIPTION
## Problem

Commit `eb7d75c` ("test(ostree): pin greenboot to exact Copr NEVR") fixed a bug where `dnf` would silently install a stock Fedora/RHEL `greenboot` package instead of the per-PR Copr build, because Copr snapshot builds use a `Release` starting at `0.<timestamp>...` which can be outranked by an official package's NEVRA. That fix only landed in `tests/greenboot-ostree.sh`.

This PR propagates the same fix to the three sibling scripts that still resolve `greenboot`/`greenboot-default-health-checks` via unscoped `dnf` calls after enabling the per-PR Copr repo:

- `tests/greenboot-fedora-iot-raw.sh`
- `tests/greenboot-bootc-anaconda-iso.sh`
- `tests/greenboot-bootc-qcow2.sh`

This was surfaced by Testing Farm failures on #193, where all three affected checks failed on an unrelated assertion because the VM had the stock `greenboot` RPM installed instead of the Copr PR build. See #195 for the full root-cause writeup.

## Fix

Adds `--from-repo='copr:copr.fedorainfracloud.org:packit:fedora-iot-greenboot-rs-<PR_NUMBER>'` to the relevant `dnf download`/`dnf reinstall`/`dnf install` calls in each script, restricting package resolution to just the just-enabled Copr repo so no other repo can compete regardless of NEVRA. The exact repo-ID format was confirmed against both the dnf4 (`dnf-plugins-core/copr.py`) and dnf5 (`dnf5/copr_plugin/copr_repo.cpp`) plugin source — both construct `copr:<hub>:<owner>:<project>` identically.

The fix lands inside the `else` (Copr) branch of the `if [[ "${USE_COMPOSE_RPMS}" == true ]]; then ... else ... fi` conditional that #178 introduced in both bootc scripts (now merged to `main`), so it doesn't touch or affect the compose-RPM install path at all.

## Validation

Pending a `/test` run on this PR. Success criteria: the Ansible/journalctl log shows the post-#190 `INFO "No previous boot journal available..."` message (not the pre-#190 `WARN`) on at least one `fedora-iot-raw` and one `bootc` target.

`rhel-10.2-bootc` / `rhel-9.8-ostree` are expected to still fail on this fork-originated PR due to an unrelated Testing Farm ranch ACL restriction — not in scope here.

Closes #195

## Updated context

The bootc scripts were further updated to replace the `dnf reinstall || dnf install --from-repo` approach with `dnf download --from-repo` + `dnf install  /tmp/copr-rpms/*.rpm`.

`dnf reinstall --from-repo` requires the exact same NEVR in the target repo, which fails when the base image ships a different Release than the Copr snapshot build (e.g. base image has `0.16.3-0.fc44`, Copr has `0.16.3-0<timestamp>.pr196...fc44`). `dnf install --from-repo` won't replace an already-installed package. Downloading first and installing from local RPMs avoids both issues, matching the ostree and compose-RPM patterns.


🤖 Assisted-by: OpenCode (Claude Sonnet 5)


