### PR TITLE
ci: use dnf builddep to install make-rpm build dependencies

### DIFF
--- a/.github/workflows/comment-ci.yaml
+++ b/.github/workflows/comment-ci.yaml
@@ -59,7 +59,8 @@ jobs:
 
       - name: Build RPMs
         run: |
-          dnf install -y git make rpm-build rust-toolset
+          dnf install -y git make rpm-build dnf-plugins-core
+          dnf builddep -y greenboot-rs.spec
           make rpm
 
       - name: Verify RPMs were created

--- a/.github/workflows/greenboot-ci.yaml
+++ b/.github/workflows/greenboot-ci.yaml
@@ -59,7 +59,8 @@ jobs:
 
       - name: Build RPMs
         run: |
-          dnf install -y git make rpm-build rust-toolset
+          dnf install -y git make rpm-build dnf-plugins-core
+          dnf builddep -y greenboot-rs.spec
           git config --global --add safe.directory /__w/greenboot-rs/greenboot-rs
           make rpm
 


### PR DESCRIPTION
## Problem

The `make-rpm` job (in both `.github/workflows/greenboot-ci.yaml` and `.github/workflows/comment-ci.yaml`) has been failing consistently on recent PRs:

```
error: Failed build dependencies:
	systemd-rpm-macros is needed by greenboot-rs-0.16.3-0.el9.x86_64
make: *** [Makefile:127: rpm] Error 11
```

Confirmed failing identically on the last several merged/open PRs: #190, #191, #192, #178, #196.

## Root cause

`greenboot-rs.spec` has an unconditional `BuildRequires: systemd-rpm-macros`. The `make-rpm` job runs in a bare `quay.io/centos/centos:stream9` container and its "Build RPMs" step only installs `git make rpm-build rust-toolset` before running `make rpm` — `systemd-rpm-macros` is never installed, so `rpmbuild` fails dependency resolution before it builds anything.

## Fix

Use `dnf builddep -y greenboot-rs.spec` (after installing `dnf-plugins-core` for the plugin) instead of hardcoding package names in the workflow. This reads `BuildRequires` straight from the spec — including the conditional `rust-toolset`/`cargo-rpm-macros` branch — so the job stays correct automatically if the spec's dependencies ever change, instead of needing a parallel hardcoded list kept in sync by hand.

## Validation

Verified locally against the exact `quay.io/centos/centos:stream9` image the job uses: `dnf install -y git make rpm-build dnf-plugins-core && dnf builddep -y greenboot-rs.spec` resolves `rust-toolset` and `systemd-rpm-macros` cleanly, and `make rpm` completes and produces all four expected RPMs (`greenboot`, `greenboot-default-health-checks`, `greenboot-rs-debugsource`, `greenboot-debuginfo`).

Also checked this doesn't regress the Fedora build path: `dnf builddep` alone only sees the spec's *static* `BuildRequires`, not the per-crate `rust-*-devel` packages that `%generate_buildrequires`/`%cargo_generate_buildrequires` enumerate dynamically during `%prep` on Fedora. That's fine here because this CI job only ever runs in the CentOS Stream 9 container above — the Fedora build path is handled entirely separately by the Makefile's own Fedora-conditional `dnf install` of `GREENBOOT_RUST_DEPENDENCIES`, which this change doesn't touch.

🤖 Assisted-by: OpenCode (Claude Sonnet 5)
