### PR TITLE
test: add kernel failure recovery CI test

### DIFF
--- a/greenboot-rs.spec
+++ b/greenboot-rs.spec
@@ -117,6 +117,7 @@ fi
 %postun -n %{pkgname}
 %systemd_postun greenboot-healthcheck.service
 %systemd_postun greenboot-set-rollback-trigger.service
+%systemd_postun greenboot-success.target
 
 %files -n %{pkgname}
 %license LICENSE LICENSE.dependencies

--- a/greenboot-rs.spec
+++ b/greenboot-rs.spec
@@ -117,7 +117,6 @@ fi
 %postun -n %{pkgname}
 %systemd_postun greenboot-healthcheck.service
 %systemd_postun greenboot-set-rollback-trigger.service
-%systemd_postun greenboot-success.target
 
 %files -n %{pkgname}
 %license LICENSE LICENSE.dependencies

--- a/src/lib/grub.rs
+++ b/src/lib/grub.rs
@@ -125,20 +125,7 @@ pub fn get_fallback() -> Result<bool> {
 }
 
 fn get_fallback_at(grub_path: &str) -> Result<bool> {
-    let grub_vars = Command::new("grub2-editenv")
-        .arg(grub_path)
-        .arg("list")
-        .output()
-        .context("Unable to list grubenv variables")?;
-
-    let output = String::from_utf8_lossy(&grub_vars.stdout);
-    for line in output.lines() {
-        if line.starts_with("fallback=") {
-            let value = line.split('=').nth(1).unwrap_or("0");
-            return Ok(value == "1");
-        }
-    }
-    Ok(false)
+    get_grub_bool_var("fallback", grub_path)
 }
 
 /// gets greenboot_rollback_trigger value, returns true if set to 1
@@ -147,30 +134,40 @@ pub fn get_rollback_trigger() -> Result<bool> {
 }
 
 fn get_rollback_trigger_at(grub_path: &str) -> Result<bool> {
+    get_grub_bool_var("greenboot_rollback_trigger", grub_path)
+}
+
+fn get_grub_bool_var(key: &str, grub_path: &str) -> Result<bool> {
     let grub_vars = Command::new("grub2-editenv")
         .arg(grub_path)
         .arg("list")
         .output()
-        .context("Unable to list grubenv variables")?;
+        .context(format!("Unable to list grubenv variables for key: {key}"))?;
 
+    if !grub_vars.status.success() {
+        bail!(
+            "grub2-editenv failed to list variables: {}",
+            String::from_utf8_lossy(&grub_vars.stderr)
+        );
+    }
+
+    let prefix = format!("{key}=");
     let output = String::from_utf8_lossy(&grub_vars.stdout);
     for line in output.lines() {
-        if line.starts_with("greenboot_rollback_trigger=") {
-            let value = line.split('=').nth(1).unwrap_or("0");
+        if let Some(value) = line.strip_prefix(&prefix) {
             return Ok(value == "1");
         }
     }
-    Ok(false) // Not set means false
+    Ok(false)
 }
 
 fn unset_grub_var(key: &str, grub_path: &str) -> Result<()> {
-    // Execute GRUB command and capture result
     let grub_result = Command::new("grub2-editenv")
         .arg(grub_path)
         .arg("unset")
         .arg(key)
         .status()
-        .context("Unable to clear boot_counter")?;
+        .context(format!("Unable to unset grubenv key: {key}"))?;
 
     if !grub_result.success() {
         bail!("Failed to unset grubenv key: {key}");

--- a/src/lib/grub.rs
+++ b/src/lib/grub.rs
@@ -82,13 +82,14 @@ fn unset_boot_counter_at(grub_path: &str) -> Result<()> {
     unset_grub_var("boot_counter", grub_path)
 }
 
-/// sets greenboot_rollback_trigger=1
+/// sets greenboot_rollback_trigger=1 and fallback=1
 pub fn set_rollback_trigger() -> Result<()> {
     set_rollback_trigger_at(GRUB_PATH)
 }
 
 fn set_rollback_trigger_at(grub_path: &str) -> Result<()> {
-    set_grub_var("greenboot_rollback_trigger", 1, grub_path)
+    set_grub_var("greenboot_rollback_trigger", 1, grub_path)?;
+    set_grub_var("fallback", 1, grub_path)
 }
 
 /// unsets greenboot_rollback_trigger
@@ -98,6 +99,46 @@ pub fn unset_rollback_trigger() -> Result<()> {
 
 fn unset_rollback_trigger_at(grub_path: &str) -> Result<()> {
     unset_grub_var("greenboot_rollback_trigger", grub_path)
+}
+
+/// sets fallback=1 for GRUB-level kernel fallback protection
+pub fn set_fallback() -> Result<()> {
+    set_fallback_at(GRUB_PATH)
+}
+
+fn set_fallback_at(grub_path: &str) -> Result<()> {
+    set_grub_var("fallback", 1, grub_path)
+}
+
+/// unsets the fallback grub variable
+pub fn unset_fallback() -> Result<()> {
+    unset_fallback_at(GRUB_PATH)
+}
+
+fn unset_fallback_at(grub_path: &str) -> Result<()> {
+    unset_grub_var("fallback", grub_path)
+}
+
+/// gets fallback value, returns true if set to 1
+pub fn get_fallback() -> Result<bool> {
+    get_fallback_at(GRUB_PATH)
+}
+
+fn get_fallback_at(grub_path: &str) -> Result<bool> {
+    let grub_vars = Command::new("grub2-editenv")
+        .arg(grub_path)
+        .arg("list")
+        .output()
+        .context("Unable to list grubenv variables")?;
+
+    let output = String::from_utf8_lossy(&grub_vars.stdout);
+    for line in output.lines() {
+        if line.starts_with("fallback=") {
+            let value = line.split('=').nth(1).unwrap_or("0");
+            return Ok(value == "1");
+        }
+    }
+    Ok(false)
 }
 
 /// gets greenboot_rollback_trigger value, returns true if set to 1
@@ -159,8 +200,9 @@ fn set_grub_var(key: &str, val: u16, grub_path: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        get_boot_counter_at, get_rollback_trigger_at, set_boot_counter_at, set_rollback_trigger_at,
-        unset_boot_counter_at, unset_rollback_trigger_at,
+        get_boot_counter_at, get_fallback_at, get_rollback_trigger_at, set_boot_counter_at,
+        set_fallback_at, set_rollback_trigger_at, unset_boot_counter_at, unset_fallback_at,
+        unset_rollback_trigger_at,
     };
     use anyhow::Context;
     use std::fs;
@@ -237,35 +279,100 @@ mod tests {
     fn test_rollback_trigger_functions() {
         let (_temp_dir, grubenv) = setup_test_paths();
 
-        // Test when rollback trigger is not set
         assert!(!get_rollback_trigger_at(&grubenv).unwrap());
+        assert!(!get_fallback_at(&grubenv).unwrap());
 
-        // Test setting rollback trigger
         set_rollback_trigger_at(&grubenv).unwrap();
         assert!(get_rollback_trigger_at(&grubenv).unwrap());
+        assert!(get_fallback_at(&grubenv).unwrap());
 
-        // Test unsetting rollback trigger
+        // unset_rollback_trigger only clears the trigger, not fallback
         unset_rollback_trigger_at(&grubenv).unwrap();
         assert!(!get_rollback_trigger_at(&grubenv).unwrap());
+        assert!(get_fallback_at(&grubenv).unwrap());
+
+        // fallback has its own lifecycle, unset independently
+        unset_fallback_at(&grubenv).unwrap();
+        assert!(!get_fallback_at(&grubenv).unwrap());
     }
 
     #[test]
     fn test_rollback_trigger_with_other_vars() {
         let (_temp_dir, grubenv) = setup_test_paths();
 
-        // Set boot counter
         set_boot_counter_at(3, &grubenv).unwrap();
-
-        // Set rollback trigger
         set_rollback_trigger_at(&grubenv).unwrap();
 
-        // Both should coexist
         assert_eq!(get_boot_counter_at(&grubenv).unwrap(), Some(3));
         assert!(get_rollback_trigger_at(&grubenv).unwrap());
+        assert!(get_fallback_at(&grubenv).unwrap());
 
-        // Unset rollback trigger, boot_counter should remain
+        // unset_rollback_trigger leaves boot_counter and fallback intact
         unset_rollback_trigger_at(&grubenv).unwrap();
         assert_eq!(get_boot_counter_at(&grubenv).unwrap(), Some(3));
         assert!(!get_rollback_trigger_at(&grubenv).unwrap());
+        assert!(get_fallback_at(&grubenv).unwrap());
+    }
+
+    #[test]
+    fn test_fallback_set_and_get() {
+        let (_temp_dir, grubenv) = setup_test_paths();
+
+        assert!(!get_fallback_at(&grubenv).unwrap());
+
+        set_fallback_at(&grubenv).unwrap();
+        assert!(get_fallback_at(&grubenv).unwrap());
+    }
+
+    #[test]
+    fn test_fallback_unset() {
+        let (_temp_dir, grubenv) = setup_test_paths();
+
+        set_fallback_at(&grubenv).unwrap();
+        assert!(get_fallback_at(&grubenv).unwrap());
+
+        unset_fallback_at(&grubenv).unwrap();
+        assert!(!get_fallback_at(&grubenv).unwrap());
+    }
+
+    #[test]
+    fn test_fallback_unset_when_not_set() {
+        let (_temp_dir, grubenv) = setup_test_paths();
+
+        unset_fallback_at(&grubenv).unwrap();
+        assert!(!get_fallback_at(&grubenv).unwrap());
+    }
+
+    #[test]
+    fn test_fallback_set_via_rollback_trigger() {
+        let (_temp_dir, grubenv) = setup_test_paths();
+
+        set_rollback_trigger_at(&grubenv).unwrap();
+        assert!(get_fallback_at(&grubenv).unwrap());
+        assert!(get_rollback_trigger_at(&grubenv).unwrap());
+    }
+
+    #[test]
+    fn test_fallback_coexists_with_boot_counter() {
+        let (_temp_dir, grubenv) = setup_test_paths();
+
+        set_boot_counter_at(3, &grubenv).unwrap();
+        set_rollback_trigger_at(&grubenv).unwrap();
+
+        assert_eq!(get_boot_counter_at(&grubenv).unwrap(), Some(3));
+        assert!(get_fallback_at(&grubenv).unwrap());
+        assert!(get_rollback_trigger_at(&grubenv).unwrap());
+    }
+
+    #[test]
+    fn test_fallback_independent_unset() {
+        let (_temp_dir, grubenv) = setup_test_paths();
+
+        set_rollback_trigger_at(&grubenv).unwrap();
+        assert!(get_fallback_at(&grubenv).unwrap());
+
+        unset_fallback_at(&grubenv).unwrap();
+        assert!(!get_fallback_at(&grubenv).unwrap());
+        assert!(get_rollback_trigger_at(&grubenv).unwrap());
     }
 }

--- a/src/lib/grub.rs
+++ b/src/lib/grub.rs
@@ -82,25 +82,6 @@ fn unset_boot_counter_at(grub_path: &str) -> Result<()> {
     unset_grub_var("boot_counter", grub_path)
 }
 
-/// sets greenboot_rollback_trigger=1 and fallback=1
-pub fn set_rollback_trigger() -> Result<()> {
-    set_rollback_trigger_at(GRUB_PATH)
-}
-
-fn set_rollback_trigger_at(grub_path: &str) -> Result<()> {
-    set_grub_var("greenboot_rollback_trigger", 1, grub_path)?;
-    set_grub_var("fallback", 1, grub_path)
-}
-
-/// unsets greenboot_rollback_trigger
-pub fn unset_rollback_trigger() -> Result<()> {
-    unset_rollback_trigger_at(GRUB_PATH)
-}
-
-fn unset_rollback_trigger_at(grub_path: &str) -> Result<()> {
-    unset_grub_var("greenboot_rollback_trigger", grub_path)
-}
-
 /// sets fallback=1 for GRUB-level kernel fallback protection
 pub fn set_fallback() -> Result<()> {
     set_fallback_at(GRUB_PATH)
@@ -128,13 +109,31 @@ fn get_fallback_at(grub_path: &str) -> Result<bool> {
     get_grub_bool_var("fallback", grub_path)
 }
 
-/// gets greenboot_rollback_trigger value, returns true if set to 1
-pub fn get_rollback_trigger() -> Result<bool> {
-    get_rollback_trigger_at(GRUB_PATH)
+/// sets greenboot_next_deployment_id to the given deployment ID string
+pub fn set_next_deployment_id(id: &str) -> Result<()> {
+    set_next_deployment_id_at(id, GRUB_PATH)
 }
 
-fn get_rollback_trigger_at(grub_path: &str) -> Result<bool> {
-    get_grub_bool_var("greenboot_rollback_trigger", grub_path)
+fn set_next_deployment_id_at(id: &str, grub_path: &str) -> Result<()> {
+    set_grub_str_var("greenboot_next_deployment_id", id, grub_path)
+}
+
+/// unsets greenboot_next_deployment_id
+pub fn unset_next_deployment_id() -> Result<()> {
+    unset_next_deployment_id_at(GRUB_PATH)
+}
+
+fn unset_next_deployment_id_at(grub_path: &str) -> Result<()> {
+    unset_grub_var("greenboot_next_deployment_id", grub_path)
+}
+
+/// returns the stored deployment ID, or None if not set
+pub fn get_next_deployment_id() -> Result<Option<String>> {
+    get_next_deployment_id_at(GRUB_PATH)
+}
+
+fn get_next_deployment_id_at(grub_path: &str) -> Result<Option<String>> {
+    get_grub_str_var("greenboot_next_deployment_id", grub_path)
 }
 
 fn get_grub_bool_var(key: &str, grub_path: &str) -> Result<bool> {
@@ -194,12 +193,56 @@ fn set_grub_var(key: &str, val: u16, grub_path: &str) -> Result<()> {
     Ok(())
 }
 
+fn set_grub_str_var(key: &str, val: &str, grub_path: &str) -> Result<()> {
+    let grub_result = Command::new("grub2-editenv")
+        .arg(grub_path)
+        .arg("set")
+        .arg(format!("{key}={val}"))
+        .status()
+        .context("Unable to set grubenv")?;
+
+    if !grub_result.success() {
+        bail!("Failed to set grubenv key: {key}");
+    }
+
+    log::info!("Set grubenv: {key}={val}");
+    Ok(())
+}
+
+fn get_grub_str_var(key: &str, grub_path: &str) -> Result<Option<String>> {
+    let grub_vars = Command::new("grub2-editenv")
+        .arg(grub_path)
+        .arg("list")
+        .output()
+        .context(format!("Unable to list grubenv variables for key: {key}"))?;
+
+    if !grub_vars.status.success() {
+        bail!(
+            "grub2-editenv failed to list variables: {}",
+            String::from_utf8_lossy(&grub_vars.stderr)
+        );
+    }
+
+    let prefix = format!("{key}=");
+    let output = String::from_utf8_lossy(&grub_vars.stdout);
+    for line in output.lines() {
+        if let Some(value) = line.strip_prefix(&prefix) {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            return Ok(Some(trimmed.to_string()));
+        }
+    }
+    Ok(None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        get_boot_counter_at, get_fallback_at, get_rollback_trigger_at, set_boot_counter_at,
-        set_fallback_at, set_rollback_trigger_at, unset_boot_counter_at, unset_fallback_at,
-        unset_rollback_trigger_at,
+        get_boot_counter_at, get_fallback_at, get_next_deployment_id_at, set_boot_counter_at,
+        set_fallback_at, set_next_deployment_id_at, unset_boot_counter_at, unset_fallback_at,
+        unset_next_deployment_id_at,
     };
     use anyhow::Context;
     use std::fs;
@@ -273,41 +316,66 @@ mod tests {
     }
 
     #[test]
-    fn test_rollback_trigger_functions() {
+    fn test_next_deployment_id_set_and_get() {
         let (_temp_dir, grubenv) = setup_test_paths();
 
-        assert!(!get_rollback_trigger_at(&grubenv).unwrap());
-        assert!(!get_fallback_at(&grubenv).unwrap());
+        assert_eq!(get_next_deployment_id_at(&grubenv).unwrap(), None);
 
-        set_rollback_trigger_at(&grubenv).unwrap();
-        assert!(get_rollback_trigger_at(&grubenv).unwrap());
-        assert!(get_fallback_at(&grubenv).unwrap());
-
-        // unset_rollback_trigger only clears the trigger, not fallback
-        unset_rollback_trigger_at(&grubenv).unwrap();
-        assert!(!get_rollback_trigger_at(&grubenv).unwrap());
-        assert!(get_fallback_at(&grubenv).unwrap());
-
-        // fallback has its own lifecycle, unset independently
-        unset_fallback_at(&grubenv).unwrap();
-        assert!(!get_fallback_at(&grubenv).unwrap());
+        let id = "sha256:abc123def456";
+        set_next_deployment_id_at(id, &grubenv).unwrap();
+        assert_eq!(
+            get_next_deployment_id_at(&grubenv).unwrap(),
+            Some(id.to_string())
+        );
     }
 
     #[test]
-    fn test_rollback_trigger_with_other_vars() {
+    fn test_next_deployment_id_unset() {
         let (_temp_dir, grubenv) = setup_test_paths();
 
+        let id = "sha256:abc123def456";
+        set_next_deployment_id_at(id, &grubenv).unwrap();
+        assert!(get_next_deployment_id_at(&grubenv).unwrap().is_some());
+
+        unset_next_deployment_id_at(&grubenv).unwrap();
+        assert_eq!(get_next_deployment_id_at(&grubenv).unwrap(), None);
+    }
+
+    #[test]
+    fn test_next_deployment_id_coexists_with_boot_counter() {
+        let (_temp_dir, grubenv) = setup_test_paths();
+
+        let id = "sha256:abc123def456";
         set_boot_counter_at(3, &grubenv).unwrap();
-        set_rollback_trigger_at(&grubenv).unwrap();
+        set_next_deployment_id_at(id, &grubenv).unwrap();
 
         assert_eq!(get_boot_counter_at(&grubenv).unwrap(), Some(3));
-        assert!(get_rollback_trigger_at(&grubenv).unwrap());
+        assert_eq!(
+            get_next_deployment_id_at(&grubenv).unwrap(),
+            Some(id.to_string())
+        );
+
+        unset_next_deployment_id_at(&grubenv).unwrap();
+        assert_eq!(get_boot_counter_at(&grubenv).unwrap(), Some(3));
+        assert_eq!(get_next_deployment_id_at(&grubenv).unwrap(), None);
+    }
+
+    #[test]
+    fn test_next_deployment_id_coexists_with_fallback() {
+        let (_temp_dir, grubenv) = setup_test_paths();
+
+        let id = "sha256:abc123def456";
+        set_next_deployment_id_at(id, &grubenv).unwrap();
+        set_fallback_at(&grubenv).unwrap();
+
+        assert_eq!(
+            get_next_deployment_id_at(&grubenv).unwrap(),
+            Some(id.to_string())
+        );
         assert!(get_fallback_at(&grubenv).unwrap());
 
-        // unset_rollback_trigger leaves boot_counter and fallback intact
-        unset_rollback_trigger_at(&grubenv).unwrap();
-        assert_eq!(get_boot_counter_at(&grubenv).unwrap(), Some(3));
-        assert!(!get_rollback_trigger_at(&grubenv).unwrap());
+        unset_next_deployment_id_at(&grubenv).unwrap();
+        assert_eq!(get_next_deployment_id_at(&grubenv).unwrap(), None);
         assert!(get_fallback_at(&grubenv).unwrap());
     }
 
@@ -341,35 +409,29 @@ mod tests {
     }
 
     #[test]
-    fn test_fallback_set_via_rollback_trigger() {
-        let (_temp_dir, grubenv) = setup_test_paths();
-
-        set_rollback_trigger_at(&grubenv).unwrap();
-        assert!(get_fallback_at(&grubenv).unwrap());
-        assert!(get_rollback_trigger_at(&grubenv).unwrap());
-    }
-
-    #[test]
     fn test_fallback_coexists_with_boot_counter() {
         let (_temp_dir, grubenv) = setup_test_paths();
 
         set_boot_counter_at(3, &grubenv).unwrap();
-        set_rollback_trigger_at(&grubenv).unwrap();
+        set_fallback_at(&grubenv).unwrap();
 
         assert_eq!(get_boot_counter_at(&grubenv).unwrap(), Some(3));
         assert!(get_fallback_at(&grubenv).unwrap());
-        assert!(get_rollback_trigger_at(&grubenv).unwrap());
     }
 
     #[test]
-    fn test_fallback_independent_unset() {
+    fn test_fallback_independent_of_deployment_id() {
         let (_temp_dir, grubenv) = setup_test_paths();
 
-        set_rollback_trigger_at(&grubenv).unwrap();
+        let id = "sha256:abc123def456";
+        set_next_deployment_id_at(id, &grubenv).unwrap();
+        set_fallback_at(&grubenv).unwrap();
+
+        unset_next_deployment_id_at(&grubenv).unwrap();
+        assert_eq!(get_next_deployment_id_at(&grubenv).unwrap(), None);
         assert!(get_fallback_at(&grubenv).unwrap());
 
         unset_fallback_at(&grubenv).unwrap();
         assert!(!get_fallback_at(&grubenv).unwrap());
-        assert!(get_rollback_trigger_at(&grubenv).unwrap());
     }
 }

--- a/src/lib/handler.rs
+++ b/src/lib/handler.rs
@@ -102,7 +102,7 @@ fn get_rpm_ostree_deployment_id(key: &str) -> Option<String> {
         .ok()?;
 
     if !output.status.success() {
-        log::warn!("Error parsing rpmostree status");
+        log::warn!("Error parsing rpm-ostree status");
         return None;
     }
 
@@ -137,11 +137,19 @@ pub fn handle_reboot(force: bool) -> Result<()> {
     Ok(())
 }
 
-/// Rollback to the previous deployment if the boot counter allows.
-/// When `force` is true, bypass the boot_counter check entirely
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RollbackMode {
+    /// GRUB kernel fallback detected — bypass boot_counter and force rollback immediately.
+    Forced,
+    /// Normal healthcheck-driven rollback — respect boot_counter guard.
+    Normal,
+}
+
+/// `RollbackMode::Forced` bypasses the boot_counter check entirely
 /// (used when GRUB kernel fallback is detected and rollback must be made permanent).
-pub fn handle_rollback(force: bool) -> Result<()> {
-    if !force {
+/// `RollbackMode::Normal` only proceeds if boot_counter has reached zero.
+pub fn handle_rollback(mode: RollbackMode) -> Result<()> {
+    if mode == RollbackMode::Normal {
         let boot_counter = get_boot_counter()?;
 
         match boot_counter {

--- a/src/lib/handler.rs
+++ b/src/lib/handler.rs
@@ -52,6 +52,78 @@ pub fn detect_os_deployment() -> Option<&'static str> {
     }
 }
 
+/// Returns the deployment ID of the currently booted deployment, or None
+/// if not on an ostree-based system or if the query fails.
+pub fn get_booted_deployment_id() -> Option<String> {
+    match detect_os_deployment() {
+        Some("bootc") => get_bootc_deployment_id("booted"),
+        Some("rpm-ostree") => get_rpm_ostree_deployment_id("booted"),
+        _ => None,
+    }
+}
+
+/// Returns the deployment ID of the staged (pending) deployment, or None
+/// if not on an ostree-based system or if no deployment is staged.
+pub fn get_staged_deployment_id() -> Option<String> {
+    match detect_os_deployment() {
+        Some("bootc") => get_bootc_deployment_id("staged"),
+        Some("rpm-ostree") => get_rpm_ostree_deployment_id("staged"),
+        _ => None,
+    }
+}
+
+fn get_bootc_deployment_id(key: &str) -> Option<String> {
+    let mut args = vec!["status", "--json"];
+    if key == "booted" {
+        args.insert(1, "--booted");
+    }
+
+    let output = Command::new("bootc").args(&args).output().ok()?;
+
+    if !output.status.success() {
+        log::warn!("Error parsing bootc status");
+        return None;
+    }
+
+    let json: Value = serde_json::from_slice(&output.stdout).ok()?;
+
+    json.get("status")
+        .and_then(|s| s.get(key))
+        .and_then(|d| d.get("image"))
+        .and_then(|i| i.get("imageDigest"))
+        .and_then(|d| d.as_str())
+        .map(|s| s.to_string())
+}
+
+fn get_rpm_ostree_deployment_id(key: &str) -> Option<String> {
+    let output = Command::new("rpm-ostree")
+        .args(["status", "--json"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        log::warn!("Error parsing rpmostree status");
+        return None;
+    }
+
+    let json: Value = serde_json::from_slice(&output.stdout).ok()?;
+    let deployments = json.get("deployments")?.as_array()?;
+
+    for deployment in deployments {
+        if deployment
+            .get(key)
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            return deployment
+                .get("checksum")
+                .and_then(|c| c.as_str())
+                .map(|s| s.to_string());
+        }
+    }
+    None
+}
+
 /// reboots the system if boot_counter is greater than 0 or can be forced too
 pub fn handle_reboot(force: bool) -> Result<()> {
     if !force {
@@ -66,39 +138,44 @@ pub fn handle_reboot(force: bool) -> Result<()> {
 }
 
 /// Rollback to the previous deployment if the boot counter allows.
-pub fn handle_rollback() -> Result<()> {
-    let boot_counter = get_boot_counter()?;
+/// When `force` is true, bypass the boot_counter check entirely
+/// (used when GRUB kernel fallback is detected and rollback must be made permanent).
+pub fn handle_rollback(force: bool) -> Result<()> {
+    if !force {
+        let boot_counter = get_boot_counter()?;
 
-    match boot_counter {
-        // Exit early if boot_counter is not set
-        None => {
-            bail!("System is unhealthy but boot_counter is not set, manual intervention required")
-        }
-        // Proceed with rollback if boot_counter is <= 0
-        Some(counter) if counter <= 0 => {
-            log::info!("Greenboot will now attempt to rollback to a previous deployment.");
-            if let Some(deployment_cmd) = detect_os_deployment() {
-                log::info!("Deployment manager '{deployment_cmd}' detected, attempting rollback.");
-                let status = Command::new(deployment_cmd)
-                    .arg("rollback")
-                    .status()
-                    .context(format!("Failed to execute '{deployment_cmd} rollback'"))?;
-
-                if !status.success() {
-                    bail!(
-                        "Rollback with '{}' failed with status: {}",
-                        deployment_cmd,
-                        status
-                    );
-                }
-            } else {
-                bail!("Rollback only supported in bootc or rpm-ostree environment.");
+        match boot_counter {
+            None => {
+                bail!(
+                    "System is unhealthy but boot_counter is not set, manual intervention required"
+                )
             }
-            Ok(())
+            Some(counter) if counter > 0 => {
+                bail!("Rollback not initiated as boot_counter is {}", counter)
+            }
+            _ => {}
         }
-        // Reject if boot_counter is > 0
-        Some(counter) => bail!("Rollback not initiated as boot_counter is {}", counter),
     }
+
+    log::info!("Greenboot will now attempt to rollback to a previous deployment.");
+    if let Some(deployment_cmd) = detect_os_deployment() {
+        log::info!("Deployment manager '{deployment_cmd}' detected, attempting rollback.");
+        let status = Command::new(deployment_cmd)
+            .arg("rollback")
+            .status()
+            .context(format!("Failed to execute '{deployment_cmd} rollback'"))?;
+
+        if !status.success() {
+            bail!(
+                "Rollback with '{}' failed with status: {}",
+                deployment_cmd,
+                status
+            );
+        }
+    } else {
+        bail!("Rollback only supported in bootc or rpm-ostree environment.");
+    }
+    Ok(())
 }
 
 /// writes greenboot status to motd.d/boot-status

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 use config::{Config, File, FileFormat};
 use greenboot::detect_os_deployment;
 use greenboot::{
-    get_boot_counter, get_rollback_trigger, handle_motd, handle_reboot, handle_rollback,
-    run_diagnostics, run_green, run_red, set_boot_counter, set_boot_status, set_rollback_trigger,
-    unset_boot_counter, unset_rollback_trigger,
+    get_boot_counter, get_fallback, get_rollback_trigger, handle_motd, handle_reboot,
+    handle_rollback, run_diagnostics, run_green, run_red, set_boot_counter, set_boot_status,
+    set_rollback_trigger, unset_boot_counter, unset_fallback, unset_rollback_trigger,
 };
 use greenboot::{is_boot_rw, remount_boot_ro, remount_boot_rw};
 use std::{process::Command, sync::OnceLock};
@@ -251,7 +251,12 @@ fn health_check() -> Result<()> {
         }
     };
 
-    // Rest of the function remains the same...
+    if !container_mode && get_fallback().unwrap_or(false) {
+        log::info!("Kernel booted successfully, disarming GRUB fallback before healthchecks");
+        with_boot_rw(unset_fallback)
+            .unwrap_or_else(|e| log::error!("Failed to unset GRUB fallback: {e}"));
+    }
+
     handle_motd(&generate_motd_message(
         "Greenboot healthcheck is in progress",
         previous_rollback,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,13 @@
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand, ValueEnum};
 use config::{Config, File, FileFormat};
-use greenboot::{detect_os_deployment, get_booted_deployment_id, get_staged_deployment_id};
 use greenboot::{
-    get_boot_counter, get_fallback, get_next_deployment_id, handle_motd, handle_reboot,
-    handle_rollback, run_diagnostics, run_green, run_red, set_boot_counter, set_boot_status,
-    set_fallback, set_next_deployment_id, unset_boot_counter, unset_fallback,
+    RollbackMode, get_boot_counter, get_fallback, get_next_deployment_id, handle_motd,
+    handle_reboot, handle_rollback, run_diagnostics, run_green, run_red, set_boot_counter,
+    set_boot_status, set_fallback, set_next_deployment_id, unset_boot_counter, unset_fallback,
     unset_next_deployment_id,
 };
+use greenboot::{detect_os_deployment, get_booted_deployment_id, get_staged_deployment_id};
 use greenboot::{is_boot_rw, remount_boot_ro, remount_boot_rw};
 use std::{process::Command, sync::OnceLock};
 
@@ -208,7 +208,11 @@ fn check_previous_rollback() -> Result<bool> {
 fn detect_grub_fallback() -> bool {
     let expected_id = match get_next_deployment_id() {
         Ok(Some(id)) => id,
-        _ => return false,
+        Ok(None) => return false,
+        Err(e) => {
+            log::error!("{e}");
+            return false;
+        }
     };
 
     let booted_id = match get_booted_deployment_id() {
@@ -261,39 +265,62 @@ fn health_check() -> Result<()> {
     let mut previous_rollback = false;
 
     if !container_mode {
-        // Detect GRUB-level kernel fallback via deployment ID comparison.
-        // If mismatch, clear next_deployment_id immediately to prevent rollback loop.
-        let grub_fallback = detect_grub_fallback();
-        if grub_fallback {
-            previous_rollback = true;
-            log::info!("GRUB kernel fallback detected - new deployment failed to boot");
-            log::info!(
-                "Making GRUB fallback permanent by rolling back to the currently booted deployment"
-            );
-            match handle_rollback(true) {
-                Ok(()) => {
-                    log::info!("Rollback to previous deployment completed successfully");
-                    with_boot_rw(unset_next_deployment_id)
-                        .unwrap_or_else(|e| log::error!("Failed to clear next-deployment-id: {e}"));
-                }
-                Err(e) => log::error!("Failed to make GRUB fallback permanent: {e}"),
-            }
-        } else if check_previous_rollback().unwrap_or(false) {
-            previous_rollback = true;
-            match detect_os_deployment() {
-                Some(manager) => log::info!(
-                    "FALLBACK BOOT DETECTED! Default {manager} deployment has been rolled back."
-                ),
-                None => log::info!("FALLBACK BOOT DETECTED! Cannot determine the deployment type."),
-            }
+        enum BootState {
+            GrubFallback,
+            PreviousRollback,
+            NormalBoot,
         }
 
-        // Disarm GRUB fallback entry if the kernel booted successfully
-        if get_fallback().unwrap_or(false) {
-            log::info!("Kernel booted successfully, disarming GRUB fallback before healthchecks");
-            with_boot_rw(unset_fallback).unwrap_or_else(|e: anyhow::Error| {
-                log::error!("Failed to unset GRUB fallback: {e}")
-            });
+        let boot_state = if detect_grub_fallback() {
+            BootState::GrubFallback
+        } else if check_previous_rollback().unwrap_or(false) {
+            BootState::PreviousRollback
+        } else {
+            BootState::NormalBoot
+        };
+
+        match boot_state {
+            BootState::GrubFallback => {
+                previous_rollback = true;
+                log::info!("GRUB kernel fallback detected - new deployment failed to boot");
+                log::info!(
+                    "Making GRUB fallback permanent by rolling back to the currently booted deployment"
+                );
+                match handle_rollback(RollbackMode::Forced) {
+                    Ok(()) => {
+                        log::info!("Rollback to previous deployment completed successfully");
+                        with_boot_rw(|| {
+                            unset_next_deployment_id()?;
+                            unset_fallback()
+                        })
+                        .unwrap_or_else(|e| {
+                            log::error!("Failed to clear grub vars after rollback: {e}")
+                        });
+                    }
+                    Err(e) => log::error!("Failed to make GRUB fallback permanent: {e}"),
+                }
+            }
+            BootState::PreviousRollback => {
+                previous_rollback = true;
+                match detect_os_deployment() {
+                    Some(manager) => log::info!(
+                        "FALLBACK BOOT DETECTED! Default {manager} deployment has been rolled back."
+                    ),
+                    None => {
+                        log::info!("FALLBACK BOOT DETECTED! Cannot determine the deployment type.")
+                    }
+                }
+            }
+            BootState::NormalBoot => {
+                if get_fallback().unwrap_or(false) {
+                    log::info!(
+                        "Kernel booted successfully, disarming GRUB fallback before healthchecks"
+                    );
+                    with_boot_rw(unset_fallback).unwrap_or_else(|e: anyhow::Error| {
+                        log::error!("Failed to unset GRUB fallback: {e}")
+                    });
+                }
+            }
         }
     }
 
@@ -359,7 +386,7 @@ fn health_check() -> Result<()> {
                             log::info!(
                                 "Boot counter exhausted and next-deployment-id is set - initiating rollback"
                             );
-                            match handle_rollback(false) {
+                            match handle_rollback(RollbackMode::Normal) {
                                 Ok(()) => {
                                     log::info!("Rollback successful");
                                     with_boot_rw(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -477,9 +477,13 @@ fn main() -> Result<()> {
                 return Ok(());
             }
 
-            let deployment_id = get_staged_deployment_id().ok_or_else(|| {
-                anyhow::anyhow!("Failed to get staged deployment ID - is an update staged?")
-            })?;
+            let deployment_id = match get_staged_deployment_id() {
+                Some(id) => id,
+                None => {
+                    log::info!("No staged deployment found; nothing to do.");
+                    return Ok(());
+                }
+            };
 
             log::info!("Setting rollback trigger for deployment: {deployment_id}");
             with_boot_rw(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,12 @@
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand, ValueEnum};
 use config::{Config, File, FileFormat};
-use greenboot::detect_os_deployment;
+use greenboot::{detect_os_deployment, get_booted_deployment_id, get_staged_deployment_id};
 use greenboot::{
-    get_boot_counter, get_fallback, get_rollback_trigger, handle_motd, handle_reboot,
+    get_boot_counter, get_fallback, get_next_deployment_id, handle_motd, handle_reboot,
     handle_rollback, run_diagnostics, run_green, run_red, set_boot_counter, set_boot_status,
-    set_rollback_trigger, unset_boot_counter, unset_fallback, unset_rollback_trigger,
+    set_fallback, set_next_deployment_id, unset_boot_counter, unset_fallback,
+    unset_next_deployment_id,
 };
 use greenboot::{is_boot_rw, remount_boot_ro, remount_boot_rw};
 use std::{process::Command, sync::OnceLock};
@@ -201,6 +202,33 @@ fn check_previous_rollback() -> Result<bool> {
     Ok(success)
 }
 
+/// Detect GRUB-level kernel fallback by comparing the stored next_deployment_id
+/// against the currently booted deployment. A mismatch means GRUB fell back to
+/// the previous deployment (e.g. due to kernel panic on the new one).
+fn detect_grub_fallback() -> bool {
+    let expected_id = match get_next_deployment_id() {
+        Ok(Some(id)) => id,
+        _ => return false,
+    };
+
+    let booted_id = match get_booted_deployment_id() {
+        Some(id) => id,
+        None => {
+            log::warn!("Could not determine booted deployment ID, skipping fallback detection");
+            return false;
+        }
+    };
+
+    if booted_id != expected_id {
+        log::warn!(
+            "GRUB kernel fallback detected: expected deployment {expected_id}, booted {booted_id}"
+        );
+        return true;
+    }
+
+    false
+}
+
 /// Generate appropriate MOTD message with optional fallback prefix
 /// Generate MOTD message using pre-checked rollback status
 fn generate_motd_message(base_msg: &str, previous_rollback: bool) -> Result<String> {
@@ -230,31 +258,43 @@ fn health_check() -> Result<()> {
         log::info!("Container environment detected; skipping reboot and rollback handling");
     }
 
-    // Check rollback status with graceful error handling
-    let previous_rollback = match check_previous_rollback() {
-        Ok(status) => {
-            if status {
-                match detect_os_deployment() {
-                    Some(manager) => log::info!(
-                        "FALLBACK BOOT DETECTED! Default {manager} deployment has been rolled back."
-                    ),
-                    None => log::info!(
-                        "FALLBACK BOOT DETECTED! Cannot rollback as its available only on rpm-ostree or bootc system."
-                    ),
-                }
-            }
-            status
-        }
-        Err(e) => {
-            log::warn!("Failed to check previous rollback status: {e}. Defaulting to false.");
-            false
-        }
-    };
+    let mut previous_rollback = false;
 
-    if !container_mode && get_fallback().unwrap_or(false) {
-        log::info!("Kernel booted successfully, disarming GRUB fallback before healthchecks");
-        with_boot_rw(unset_fallback)
-            .unwrap_or_else(|e| log::error!("Failed to unset GRUB fallback: {e}"));
+    if !container_mode {
+        // Detect GRUB-level kernel fallback via deployment ID comparison.
+        // If mismatch, clear next_deployment_id immediately to prevent rollback loop.
+        let grub_fallback = detect_grub_fallback();
+        if grub_fallback {
+            previous_rollback = true;
+            log::info!("GRUB kernel fallback detected - new deployment failed to boot");
+            log::info!(
+                "Making GRUB fallback permanent by rolling back to the currently booted deployment"
+            );
+            match handle_rollback(true) {
+                Ok(()) => {
+                    log::info!("Rollback to previous deployment completed successfully");
+                    with_boot_rw(unset_next_deployment_id)
+                        .unwrap_or_else(|e| log::error!("Failed to clear next-deployment-id: {e}"));
+                }
+                Err(e) => log::error!("Failed to make GRUB fallback permanent: {e}"),
+            }
+        } else if check_previous_rollback().unwrap_or(false) {
+            previous_rollback = true;
+            match detect_os_deployment() {
+                Some(manager) => log::info!(
+                    "FALLBACK BOOT DETECTED! Default {manager} deployment has been rolled back."
+                ),
+                None => log::info!("FALLBACK BOOT DETECTED! Cannot determine the deployment type."),
+            }
+        }
+
+        // Disarm GRUB fallback entry if the kernel booted successfully
+        if get_fallback().unwrap_or(false) {
+            log::info!("Kernel booted successfully, disarming GRUB fallback before healthchecks");
+            with_boot_rw(unset_fallback).unwrap_or_else(|e: anyhow::Error| {
+                log::error!("Failed to unset GRUB fallback: {e}")
+            });
+        }
     }
 
     handle_motd(&generate_motd_message(
@@ -279,11 +319,10 @@ fn health_check() -> Result<()> {
 
             if !container_mode {
                 with_boot_rw(|| set_boot_status(true))?;
-
-                // Unset rollback trigger on successful health check
-                if get_rollback_trigger().unwrap_or(false) {
-                    with_boot_rw(unset_rollback_trigger)
-                        .unwrap_or_else(|e| log::error!("Failed to unset rollback trigger: {e}"));
+                // Unset next_deployment_id on successful health check
+                if get_next_deployment_id().unwrap_or(None).is_some() {
+                    with_boot_rw(unset_next_deployment_id)
+                        .unwrap_or_else(|e| log::error!("Failed to unset next-deployment-id: {e}"));
                 }
             }
 
@@ -316,16 +355,16 @@ fn health_check() -> Result<()> {
                     }
                     Some(_) => {
                         // Boot counter reached 0 (or negative) - check rollback trigger
-                        if get_rollback_trigger().unwrap_or(false) {
+                        if get_next_deployment_id().unwrap_or(None).is_some() {
                             log::info!(
-                                "Boot counter exhausted and rollback trigger is set - initiating rollback"
+                                "Boot counter exhausted and next-deployment-id is set - initiating rollback"
                             );
-                            match handle_rollback() {
+                            match handle_rollback(false) {
                                 Ok(()) => {
                                     log::info!("Rollback successful");
                                     with_boot_rw(|| {
                                         unset_boot_counter()?;
-                                        unset_rollback_trigger()?;
+                                        unset_next_deployment_id()?;
                                         Ok(())
                                     })
                                     .unwrap_or_else(|e| {
@@ -341,7 +380,7 @@ fn health_check() -> Result<()> {
                             }
                         } else {
                             log::warn!(
-                                "Boot counter exhausted but no rollback trigger set - manual intervention required"
+                                "Boot counter exhausted but no next-deployment-id set - manual intervention required"
                             );
                             bail!("Manual intervention required - no rollback trigger");
                         }
@@ -410,8 +449,16 @@ fn main() -> Result<()> {
                 log::info!("Container environment detected; skipping rollback trigger updates");
                 return Ok(());
             }
-            log::info!("Setting rollback trigger for next boot...");
-            with_boot_rw(set_rollback_trigger)?;
+
+            let deployment_id = get_staged_deployment_id().ok_or_else(|| {
+                anyhow::anyhow!("Failed to get staged deployment ID - is an update staged?")
+            })?;
+
+            log::info!("Setting rollback trigger for deployment: {deployment_id}");
+            with_boot_rw(|| {
+                set_next_deployment_id(&deployment_id)?;
+                set_fallback()
+            })?;
             log::info!("Rollback trigger set successfully.");
             Ok(())
         }

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -338,6 +338,7 @@ sudo virt-install  --name="${TEST_UUID}-uefi"\
                    --os-variant ${OS_VARIANT} \
                    --cdrom "/var/lib/libvirt/images/install.iso" \
                    --boot ${BOOT_ARGS} \
+                   --tpm none \
                    --graphics none \
                    --serial file,path=${CONSOLE_LOG} \
                    --noautoconsole \

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -304,6 +304,7 @@ sudo virt-install  --name="${TEST_UUID}-uefi"\
                    --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --boot ${BOOT_ARGS} \
+                   --tpm none \
                    --graphics none \
                    --serial file,path=${CONSOLE_LOG} \
                    --noautoconsole \

--- a/tests/greenboot-ostree.sh
+++ b/tests/greenboot-ostree.sh
@@ -420,6 +420,7 @@ sudo virt-install  --name="${IMAGE_KEY}"\
                    --network network=integration,mac=34:49:22:B0:83:30 \
                    --os-variant ${OS_VARIANT} \
                    --boot ${BOOT_ARGS} \
+                   --tpm none \
                    --location "${BOOT_LOCATION}" \
                    --graphics none \
                    --serial file,path=${CONSOLE_LOG} \

--- a/tests/greenboot-ostree.yaml
+++ b/tests/greenboot-ostree.yaml
@@ -271,6 +271,202 @@
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
 
+    # case: kernel failure recovery via GRUB fallback mechanism
+    # Reboot 1: finalize wget deployment to create two clean BLS entries.
+    # Reboot 2: stage sl so set-rollback-trigger fires, corrupt BLS, trigger GRUB fallback.
+    - name: create clean deployment for kernel failure test
+      block:
+        - name: install wget to create a clean deployment
+          command: rpm-ostree install wget
+          become: yes
+
+        - name: reboot to finalize deployment and create two clean BLS entries
+          reboot:
+            reboot_timeout: 600
+            post_reboot_delay: 30
+          become: yes
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+
+    - name: simulate kernel boot failure via corrupted BLS entry
+      block:
+        - name: stage sl so set-rollback-trigger fires on next shutdown
+          command: rpm-ostree install sl
+          become: yes
+
+        - name: identify the higher-version BLS entry (GRUB boots this first)
+          shell: |
+            highest_ver=0
+            highest_file=""
+            for f in /boot/loader/entries/ostree-*.conf; do
+              ver=$(grep '^version ' "$f" | awk '{print $2}')
+              if [ "$ver" -gt "$highest_ver" ]; then
+                highest_ver=$ver
+                highest_file=$f
+              fi
+            done
+            echo "$highest_file"
+          register: result_bls_entry
+          become: yes
+
+        - name: corrupt the kernel path in the higher-version BLS entry
+          shell: sed -i 's|vmlinuz-.*|vmlinuz-does-not-exist|' {{ result_bls_entry.stdout }}
+          become: yes
+
+        - name: reboot to trigger set-rollback-trigger and GRUB fallback
+          reboot:
+            reboot_timeout: 600
+            post_reboot_delay: 60
+          become: yes
+          ignore_errors: yes
+          ignore_unreachable: yes
+
+        - name: delay 120 seconds for GRUB fallback
+          pause:
+            seconds: 120
+          delegate_to: 127.0.0.1
+
+        - name: wait for connection to become reachable
+          wait_for_connection:
+            delay: 30
+
+        - name: wait for SSH to become available after kernel failure recovery
+          wait_for:
+            host: "{{ ansible_all_ipv4_addresses[0] }}"
+            port: 22
+            search_regex: OpenSSH
+            delay: 10
+          register: result_kernel_recovery
+          until: result_kernel_recovery is success
+          retries: 12
+          delay: 10
+
+        - assert:
+            that:
+              - result_kernel_recovery is succeeded
+            fail_msg: "System did not recover from kernel failure"
+            success_msg: "System recovered from kernel failure via GRUB fallback"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+
+    # case: check fallback log after kernel failure
+    - name: fallback log should be found after kernel failure recovery
+      block:
+        - name: check greenboot journal for fallback detection
+          command: journalctl -b -0 -u greenboot -u greenboot-healthcheck
+          become: yes
+          register: result_kernel_fallback_log
+
+        - assert:
+            that:
+              - "'GRUB kernel fallback detected' in result_kernel_fallback_log.stdout"
+            fail_msg: "GRUB kernel fallback log not found after kernel failure recovery"
+            success_msg: "Found GRUB kernel fallback log after kernel failure recovery"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: result_kernel_recovery is defined and result_kernel_recovery is succeeded
+
+    # case: verify fallback and rollback trigger cleared from grubenv
+    - name: fallback and greenboot_next_deployment_id should be cleared from grubenv
+      block:
+        - name: check grubenv after kernel failure recovery
+          command: grub2-editenv list
+          register: result_grubenv_kernel
+          become: yes
+
+        - assert:
+            that:
+              - "'fallback' not in result_grubenv_kernel.stdout"
+              - "'greenboot_next_deployment_id' not in result_grubenv_kernel.stdout"
+            fail_msg: "fallback or greenboot_next_deployment_id still present in grubenv"
+            success_msg: "fallback and greenboot_next_deployment_id cleared from grubenv"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: result_kernel_recovery is defined and result_kernel_recovery is succeeded
+
+    # case: check boot-complete.target after kernel failure recovery
+    - name: boot-complete.target should be active after kernel failure recovery
+      block:
+        - name: check boot-complete.target
+          command: systemctl --no-pager status boot-complete.target
+          become: yes
+          register: result_boot_complete_kernel
+          retries: 10
+          delay: 60
+          until: "'inactive' not in result_boot_complete_kernel.stdout"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: result_kernel_recovery is defined and result_kernel_recovery is succeeded
+
+    # case: check grubenv boot_success after kernel failure recovery
+    - name: grubenv should contain boot_success=1 after kernel failure recovery
+      block:
+        - name: check grubenv for boot_success
+          command: grub2-editenv list
+          register: result_grubenv_boot_success_kernel
+          become: yes
+
+        - assert:
+            that:
+              - "'boot_success=1' in result_grubenv_boot_success_kernel.stdout"
+            fail_msg: "Not found boot_success=1 after kernel failure recovery"
+            success_msg: "Found boot_success=1 after kernel failure recovery"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: result_kernel_recovery is defined and result_kernel_recovery is succeeded
+
+    # case: check /boot mount preserved after kernel failure recovery
+    - name: check /boot mount status after kernel failure recovery
+      shell: findmnt -r -o OPTIONS -n /boot | awk -F "," '{print $1}'
+      register: result_boot_mount_after_kernel
+      when: result_kernel_recovery is defined and result_kernel_recovery is succeeded
+
+    - name: /boot status should be preserved after kernel failure recovery
+      block:
+        - assert:
+            that:
+              - result_boot_mount_before.stdout == result_boot_mount_after_kernel.stdout
+            fail_msg: "/boot status is not preserved after kernel failure recovery"
+            success_msg: "/boot status is preserved after kernel failure recovery"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: result_kernel_recovery is defined and result_kernel_recovery is succeeded
+
     - assert:
         that:
           - failed_counter == "0"

--- a/usr/lib/systemd/system/greenboot-healthcheck.service
+++ b/usr/lib/systemd/system/greenboot-healthcheck.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Greenboot Health Checks Runner
 Before=boot-complete.target
-Wants=boot-complete.target
+Wants=greenboot-success.target
 OnFailureJobMode=fail
 RequiresMountsFor=/boot
 RequiresMountsFor=/etc
@@ -15,6 +15,6 @@ Restart=no
 PrivateMounts=yes
 
 [Install]
-RequiredBy=boot-complete.target
+RequiredBy=greenboot-success.target
 WantedBy=multi-user.target
 Also=greenboot-set-rollback-trigger.service

--- a/usr/lib/systemd/system/greenboot-healthcheck.service
+++ b/usr/lib/systemd/system/greenboot-healthcheck.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Greenboot Health Checks Runner
 Before=boot-complete.target
+OnSuccess=greenboot-success.target
 OnFailureJobMode=fail
 RequiresMountsFor=/boot
 RequiresMountsFor=/etc
@@ -8,12 +9,11 @@ RefuseManualStart=yes
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
+RemainAfterExit=no
 ExecStart=/usr/libexec/greenboot/greenboot health-check
 Restart=no
 PrivateMounts=yes
 
 [Install]
-RequiredBy=boot-complete.target
 WantedBy=multi-user.target
-Also=greenboot-success.target greenboot-set-rollback-trigger.service
+Also=greenboot-set-rollback-trigger.service

--- a/usr/lib/systemd/system/greenboot-healthcheck.service
+++ b/usr/lib/systemd/system/greenboot-healthcheck.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Greenboot Health Checks Runner
 Before=boot-complete.target
-OnSuccess=greenboot-success.target
+Wants=boot-complete.target
 OnFailureJobMode=fail
 RequiresMountsFor=/boot
 RequiresMountsFor=/etc
@@ -9,11 +9,12 @@ RefuseManualStart=yes
 
 [Service]
 Type=oneshot
-RemainAfterExit=no
+RemainAfterExit=yes
 ExecStart=/usr/libexec/greenboot/greenboot health-check
 Restart=no
 PrivateMounts=yes
 
 [Install]
+RequiredBy=boot-complete.target
 WantedBy=multi-user.target
 Also=greenboot-set-rollback-trigger.service

--- a/usr/lib/systemd/system/greenboot-set-rollback-trigger.service
+++ b/usr/lib/systemd/system/greenboot-set-rollback-trigger.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Greenboot Rollback trigger
 DefaultDependencies=no
-After=ostree-finalize-staged.service
+After=ostree-finalize-staged.service rpm-ostreed.service
 RequiresMountsFor=/boot
 ConditionPathExists=/run/ostree-booted
 

--- a/usr/lib/systemd/system/greenboot-set-rollback-trigger.service
+++ b/usr/lib/systemd/system/greenboot-set-rollback-trigger.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=Greenboot Rollback trigger
 DefaultDependencies=no
-Before=ostree-finalize-staged.service
+After=ostree-finalize-staged.service
 RequiresMountsFor=/boot
 ConditionPathExists=/run/ostree-booted
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/libexec/greenboot/greenboot set-rollback-trigger
+ExecStop=/usr/libexec/greenboot/greenboot set-rollback-trigger
 PrivateMounts=yes
 
 [Install]

--- a/usr/lib/systemd/system/greenboot-set-rollback-trigger.service
+++ b/usr/lib/systemd/system/greenboot-set-rollback-trigger.service
@@ -1,17 +1,15 @@
 [Unit]
 Description=Greenboot Rollback trigger
 DefaultDependencies=no
-After=local-fs.target
-Before=systemd-update-done.service greenboot-healthcheck.service
-Before=sysinit.target shutdown.target
-Conflicts=shutdown.target
-ConditionNeedsUpdate=|/etc
-ConditionNeedsUpdate=|/var
+Before=ostree-finalize-staged.service
+RequiresMountsFor=/boot
+ConditionPathExists=/run/ostree-booted
 
 [Service]
 Type=oneshot
-Restart=no
+RemainAfterExit=yes
 ExecStart=/usr/libexec/greenboot/greenboot set-rollback-trigger
+PrivateMounts=yes
 
 [Install]
-WantedBy=systemd-update-done.service greenboot-healthcheck.service
+RequiredBy=ostree-finalize-staged.service

--- a/usr/lib/systemd/system/greenboot-success.target
+++ b/usr/lib/systemd/system/greenboot-success.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=GreenBoot Healthcheck Success Target
+After=greenboot-healthcheck.service
+Requires=boot-complete.target

--- a/usr/lib/systemd/system/greenboot-success.target
+++ b/usr/lib/systemd/system/greenboot-success.target
@@ -1,7 +1,3 @@
 [Unit]
 Description=GreenBoot Healthcheck Success Target
-After=greenboot-healthcheck.service
 Requires=boot-complete.target
-
-[Install]
-WantedBy=multi-user.target

--- a/usr/lib/systemd/system/greenboot-success.target
+++ b/usr/lib/systemd/system/greenboot-success.target
@@ -1,3 +1,0 @@
-[Unit]
-Description=GreenBoot Healthcheck Success Target
-Requires=boot-complete.target


### PR DESCRIPTION
## Summary
- Add comprehensive kernel failure recovery test using BLS entry corruption
- Tests GRUB fallback mechanism introduced in PR #181
- Includes TPM emulation fix for Fedora Rawhide compatibility

## Dependencies
This PR depends on PR #181 being merged first as it builds on the GRUB fallback infrastructure.

## Test Coverage
- Creates clean deployment baseline (install wget, reboot)
- Stages new deployment with rollback trigger (install sl)
- Corrupts BLS entry kernel path to simulate boot failure
- Verifies GRUB fallback mechanism recovers to working deployment
- Validates journal logs contain "GRUB kernel fallback detected"
- Confirms system reaches boot-complete.target

## Related
- Jira: THEEDGE-4738
- Based on: PR #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)