### PR TITLE
ci: add Fedora rawhide targets after F45 branching

### DIFF
--- a/.github/workflows/comment-ci.yaml
+++ b/.github/workflows/comment-ci.yaml
@@ -135,6 +135,29 @@ jobs:
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
+  fedora-rawhide-bootc:
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+
+    steps:
+      - name: Run the tests
+        uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1 # v4.3.1
+        with:
+          compose: Fedora-44
+          api_key: ${{ secrets.TF_API_PUB_KEY }}
+          git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+          git_ref: ${{ needs.check-pull-request.outputs.ref }}
+          update_pull_request_status: true
+          pull_request_status_name: fedora-rawhide-bootc
+          tmt_context: "arch=x86_64;distro=fedora-rawhide"
+          tmt_plan_regex: bootc
+          variables: "ARCH=x86_64;TARGET_DISTRO=fedora-rawhide;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
+          timeout: 90
+          secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
+
   fedora-44-ostree:
     needs: check-pull-request
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
@@ -178,6 +201,29 @@ jobs:
           tmt_context: "arch=x86_64;distro=fedora-45"
           tmt_plan_regex: fedora-iot-raw
           variables: "ARCH=x86_64;TARGET_DISTRO=fedora-45;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
+          timeout: 90
+          secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
+
+  fedora-rawhide-ostree:
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+
+    steps:
+      - name: Run the tests
+        uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1 # v4.3.1
+        with:
+          compose: Fedora-44
+          api_key: ${{ secrets.TF_API_PUB_KEY }}
+          git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+          git_ref: ${{ needs.check-pull-request.outputs.ref }}
+          update_pull_request_status: true
+          pull_request_status_name: fedora-rawhide-ostree
+          tmt_context: "arch=x86_64;distro=fedora-rawhide"
+          tmt_plan_regex: fedora-iot-raw
+          variables: "ARCH=x86_64;TARGET_DISTRO=fedora-rawhide;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 

--- a/.github/workflows/greenboot-ci.yaml
+++ b/.github/workflows/greenboot-ci.yaml
@@ -136,6 +136,29 @@ jobs:
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 
+  fedora-rawhide-bootc:
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+
+    steps:
+      - name: Run the tests
+        uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1 # v4.3.1
+        with:
+          compose: Fedora-44
+          api_key: ${{ secrets.TF_API_PUB_KEY }}
+          git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+          git_ref: ${{ needs.check-pull-request.outputs.ref }}
+          update_pull_request_status: true
+          pull_request_status_name: fedora-rawhide-bootc
+          tmt_context: "arch=x86_64;distro=fedora-rawhide"
+          tmt_plan_regex: bootc
+          variables: "ARCH=x86_64;TARGET_DISTRO=fedora-rawhide;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
+          timeout: 90
+          secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
+
   fedora-44-ostree:
     needs: check-pull-request
     if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
@@ -179,6 +202,29 @@ jobs:
           tmt_context: "arch=x86_64;distro=fedora-45"
           tmt_plan_regex: fedora-iot-raw
           variables: "ARCH=x86_64;TARGET_DISTRO=fedora-45;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
+          timeout: 90
+          secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
+
+  fedora-rawhide-ostree:
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+
+    steps:
+      - name: Run the tests
+        uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1 # v4.3.1
+        with:
+          compose: Fedora-44
+          api_key: ${{ secrets.TF_API_PUB_KEY }}
+          git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+          git_ref: ${{ needs.check-pull-request.outputs.ref }}
+          update_pull_request_status: true
+          pull_request_status_name: fedora-rawhide-ostree
+          tmt_context: "arch=x86_64;distro=fedora-rawhide"
+          tmt_plan_regex: fedora-iot-raw
+          variables: "ARCH=x86_64;TARGET_DISTRO=fedora-rawhide;PR_NUMBER=${{ needs.check-pull-request.outputs.pr_number }}"
           timeout: 90
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }}"
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -59,6 +59,8 @@ jobs:
   - fedora-44-x86_64
   - fedora-development-aarch64
   - fedora-development
+  - fedora-rawhide-aarch64
+  - fedora-rawhide
   - fedora-eln-aarch64
   - fedora-eln
 

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -57,10 +57,17 @@ case "${ID}-${VERSION_ID}" in
         BOOT_ARGS="uefi"
         ;;
     "fedora-45")
+        OS_VARIANT="fedora-unknown"
+        BASE_IMAGE_URL="quay.io/fedora/fedora-iot:45"
+        BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
+        BOOT_ARGS="uefi"
+        ;;
+    "fedora-rawhide")
         OS_VARIANT="fedora-rawhide"
         BASE_IMAGE_URL="quay.io/fedora/fedora-iot:rawhide"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"
+        COPR_CHROOT="fedora-rawhide-${ARCH}"
         ;;
     "centos-10")
         OS_VARIANT="centos-stream9"

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -57,10 +57,17 @@ case "${ID}-${VERSION_ID}" in
         BOOT_ARGS="uefi"
         ;;
     "fedora-45")
+        OS_VARIANT="fedora-unknown"
+        BASE_IMAGE_URL="quay.io/fedora/fedora-iot:45"
+        BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
+        BOOT_ARGS="uefi"
+        ;;
+    "fedora-rawhide")
         OS_VARIANT="fedora-rawhide"
         BASE_IMAGE_URL="quay.io/fedora/fedora-iot:rawhide"
         BIB_URL="quay.io/centos-bootc/bootc-image-builder:latest"
         BOOT_ARGS="uefi"
+        COPR_CHROOT="fedora-rawhide-${ARCH}"
         ;;
     "centos-10")
         OS_VARIANT="centos-stream9"

--- a/tests/greenboot-fedora-iot-raw.sh
+++ b/tests/greenboot-fedora-iot-raw.sh
@@ -62,7 +62,12 @@ case "${ID}-${VERSION_ID}" in
         ;;
     "fedora-45")
         FEDORA_VERSION="45"
+        OS_VARIANT="fedora-unknown"
+        ;;
+    "fedora-rawhide")
+        FEDORA_VERSION="46"
         OS_VARIANT="fedora-rawhide"
+        COPR_CHROOT="fedora-rawhide-${ARCH}"
         ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
@@ -293,7 +298,7 @@ check_result
 greenprint "📦 Enabling Packit Copr repo for PR #${PR_NUMBER}"
 for _ in $(seq 0 30); do
     ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "${SSH_USER}@${GUEST_ADDRESS}" \
-        "sudo dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUMBER}"
+        "sudo dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUMBER} ${COPR_CHROOT:-}"
     copr_result=$?
     if [[ $copr_result == 0 ]]; then
         break


### PR DESCRIPTION
Fedora 45 has branched into development, rawhide is now F46.
Update test scripts to use tagged :45 images for F45 and :rawhide
for rawhide, add rawhide CI jobs using version-agnostic naming,
and add fedora-rawhide Packit Copr targets. Using "fedora-rawhide"
instead of version numbers means only FEDORA_VERSION in the ostree
script needs updating at the next branching event.


Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>