### PR TITLE
fix: allow packit to trigger koji builds and bodhi updates

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -70,14 +70,14 @@ jobs:
 
 - job: koji_build
   trigger: commit
-  allowed_pr_authors: [all_committers]
+  allowed_pr_authors: [packit, all_committers]
   dist_git_branches:
     - fedora-development
     - fedora-stable
 
 - job: bodhi_update
   trigger: commit
-  allowed_builders: [all_committers]
+  allowed_builders: [packit, all_committers]
   dist_git_branches:
     - fedora-development
     - fedora-stable


### PR DESCRIPTION
The default for allowed_pr_authors is ['packit'], but the explicit override to [all_committers] excluded the packit bot since it does not have commit access to the dist-git repo. Add packit explicitly.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>