### PR TITLE
test: request virtualized host with nested virt instead of bare metal

### DIFF
--- a/tmt/plans/greenboot-test.fmf
+++ b/tmt/plans/greenboot-test.fmf
@@ -7,6 +7,7 @@ execute:
 provision:
   hardware:
     virtualization:
+      is-virtualized: true
       is-supported: true
     cpu:
       processors: ">= 4"


### PR DESCRIPTION
CI tests provision a host to run guest VMs under libvirt/qemu, not to test the host OS itself. The is-supported hardware constraint alone was resolving to bare metal, causing intermittent CI failures when bare metal instances failed to come back within the 600s Ansible timeout after a routine host package update and reboot.

Adding is-virtualized: true requests a VM host with nested virtualization support instead, avoiding the bare metal reboot penalty.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>