### PR TITLE
test: fix bootc rollback assertions and CI Copr/DNF failures

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -57,6 +57,8 @@ jobs:
   - centos-stream-10-x86_64
   - fedora-44-aarch64
   - fedora-44-x86_64
+  - fedora-45-aarch64
+  - fedora-45-x86_64
   - fedora-development-aarch64
   - fedora-development
   - fedora-rawhide-aarch64

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -334,7 +334,7 @@ else
 RUN (dnf install -y 'dnf5-command(copr)' || dnf install -y 'dnf-command(copr)') && \
     dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUM} ${COPR_CHROOT} && \
     dnf clean metadata && \
-    dnf download --from-repo='${GREENBOOT_COPR_REPO_ID}' --destdir /tmp/copr-rpms greenboot greenboot-default-health-checks && \
+    dnf download --disablerepo='*' --enablerepo='${GREENBOOT_COPR_REPO_ID}' --destdir /tmp/copr-rpms greenboot greenboot-default-health-checks && \
     dnf install -y /tmp/copr-rpms/*.rpm && \
     rm -rf /tmp/copr-rpms && \
     systemctl enable greenboot-healthcheck.service

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -255,9 +255,9 @@ greenprint "Copying test assets"
 (
     cd ..
     cp testing_assets/passing_script.sh tests/
-    cp testing_assets/passing_binary tests/
+    cp "testing_assets/passing_binary.${ARCH}" tests/passing_binary
     cp testing_assets/failing_script.sh tests/
-    cp testing_assets/failing_binary tests/
+    cp "testing_assets/failing_binary.${ARCH}" tests/failing_binary
 )
 
 ###########################################################

--- a/tests/greenboot-bootc-anaconda-iso.sh
+++ b/tests/greenboot-bootc-anaconda-iso.sh
@@ -39,6 +39,7 @@ EDGE_USER_PASSWORD=foobar
 CONSOLE_LOG=/tmp/vm-console.log
 
 COPR_CHROOT=""
+PR_NUM="${PR_NUMBER:-0}"
 
 # RPM acquisition mode:
 #   If DOWNLOAD_NODE and COMPOSE_ID are both set -> download from compose
@@ -319,7 +320,7 @@ esac
 # just the just-enabled Copr repo so there is only one candidate regardless
 # of what other repos offer (see commit eb7d75c, which fixed the same class
 # of bug for the ostree/osbuild-composer flow).
-GREENBOOT_COPR_REPO_ID="copr:copr.fedorainfracloud.org:packit:fedora-iot-greenboot-rs-${PR_NUMBER}"
+GREENBOOT_COPR_REPO_ID="copr:copr.fedorainfracloud.org:packit:fedora-iot-greenboot-rs-${PR_NUM}"
 
 if [[ "${USE_COMPOSE_RPMS}" == true && -n "${GREENBOOT_PACKAGES_URL}" ]]; then
     tee -a Containerfile > /dev/null << EOF
@@ -331,7 +332,7 @@ EOF
 else
     tee -a Containerfile > /dev/null << EOF
 RUN (dnf install -y 'dnf5-command(copr)' || dnf install -y 'dnf-command(copr)') && \
-    dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUMBER} ${COPR_CHROOT} && \
+    dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUM} ${COPR_CHROOT} && \
     dnf clean metadata && \
     dnf download --from-repo='${GREENBOOT_COPR_REPO_ID}' --destdir /tmp/copr-rpms greenboot greenboot-default-health-checks && \
     dnf install -y /tmp/copr-rpms/*.rpm && \

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -334,7 +334,7 @@ else
 RUN (dnf install -y 'dnf5-command(copr)' || dnf install -y 'dnf-command(copr)') && \
     dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUM} ${COPR_CHROOT} && \
     dnf clean metadata && \
-    dnf download --from-repo='${GREENBOOT_COPR_REPO_ID}' --destdir /tmp/copr-rpms greenboot greenboot-default-health-checks && \
+    dnf download --disablerepo='*' --enablerepo='${GREENBOOT_COPR_REPO_ID}' --destdir /tmp/copr-rpms greenboot greenboot-default-health-checks && \
     dnf install -y /tmp/copr-rpms/*.rpm && \
     rm -rf /tmp/copr-rpms && \
     systemctl enable greenboot-healthcheck.service

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -255,9 +255,9 @@ greenprint "Copying test assets"
 (
     cd ..
     cp testing_assets/passing_script.sh tests/
-    cp testing_assets/passing_binary tests/
+    cp "testing_assets/passing_binary.${ARCH}" tests/passing_binary
     cp testing_assets/failing_script.sh tests/
-    cp testing_assets/failing_binary tests/
+    cp "testing_assets/failing_binary.${ARCH}" tests/failing_binary
 )
 
 ###########################################################

--- a/tests/greenboot-bootc-qcow2.sh
+++ b/tests/greenboot-bootc-qcow2.sh
@@ -39,6 +39,7 @@ EDGE_USER_PASSWORD=foobar
 CONSOLE_LOG=/tmp/vm-console.log
 
 COPR_CHROOT=""
+PR_NUM="${PR_NUMBER:-0}"
 
 # RPM acquisition mode:
 #   If DOWNLOAD_NODE and COMPOSE_ID are both set -> download from compose
@@ -319,7 +320,7 @@ esac
 # just the just-enabled Copr repo so there is only one candidate regardless
 # of what other repos offer (see commit eb7d75c, which fixed the same class
 # of bug for the ostree/osbuild-composer flow).
-GREENBOOT_COPR_REPO_ID="copr:copr.fedorainfracloud.org:packit:fedora-iot-greenboot-rs-${PR_NUMBER}"
+GREENBOOT_COPR_REPO_ID="copr:copr.fedorainfracloud.org:packit:fedora-iot-greenboot-rs-${PR_NUM}"
 
 if [[ "${USE_COMPOSE_RPMS}" == true && -n "${GREENBOOT_PACKAGES_URL}" ]]; then
     tee -a Containerfile > /dev/null << EOF
@@ -331,7 +332,7 @@ EOF
 else
     tee -a Containerfile > /dev/null << EOF
 RUN (dnf install -y 'dnf5-command(copr)' || dnf install -y 'dnf-command(copr)') && \
-    dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUMBER} ${COPR_CHROOT} && \
+    dnf copr enable -y packit/fedora-iot-greenboot-rs-${PR_NUM} ${COPR_CHROOT} && \
     dnf clean metadata && \
     dnf download --from-repo='${GREENBOOT_COPR_REPO_ID}' --destdir /tmp/copr-rpms greenboot greenboot-default-health-checks && \
     dnf install -y /tmp/copr-rpms/*.rpm && \

--- a/tests/greenboot-bootc.yaml
+++ b/tests/greenboot-bootc.yaml
@@ -141,7 +141,9 @@
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
 
-    # case: check greenboot-set-rollback-trigger log at first boot
+    # case: check greenboot-set-rollback-trigger ran when the upgrade was staged
+    # After `bootc upgrade`, ostree-finalize-staged stops on reboot and ExecStop
+    # runs set-rollback-trigger. That lands in the pre-upgrade boot journal (-b -7).
     - name: check greenboot-set-rollback-trigger at first boot
       block:
         - name: greenboot rollback trigger should be found here
@@ -153,7 +155,7 @@
             that:
               - "'Rollback trigger set successfully' in result_greenboot_trigger_log.stdout"
               - "'Dependency failed' not in result_greenboot_trigger_log.stdout"
-            fail_msg: "Expected greenboot trigger log or systemd update log not found, or dependency failure found"
+            fail_msg: "Expected rollback trigger success log not found, or dependency failure found"
             success_msg: "Found expected log and no dependency failures"
 
       always:
@@ -192,20 +194,28 @@
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
 
-    # case: check greenboot-set-rollback-trigger log at boot after upgrade
+    # case: first boot of the upgraded (failing) image must not re-run the trigger
+    # There is no second staged update; the trigger was already set on -b -7 shutdown.
     - name: check greenboot-set-rollback-trigger at boot after upgrade
       block:
-        - name: greenboot rollback trigger should be found here
+        - name: greenboot rollback trigger should not run on first upgraded boot
           command: journalctl -b -6 -u greenboot-set-rollback-trigger.service
           become: yes
           register: result_greenboot_trigger_log
 
+        - name: get healthcheck log from first upgraded boot
+          command: journalctl -b -6 -u greenboot-healthcheck.service --no-pager
+          become: yes
+          register: result_healthcheck_upgrade_boot
+
         - assert:
             that:
-              - "'Rollback trigger set successfully' in result_greenboot_trigger_log.stdout"
+              - "'-- No entries --' in result_greenboot_trigger_log.stdout"
+              - "'Rollback trigger set successfully' not in result_greenboot_trigger_log.stdout"
               - "'Dependency failed' not in result_greenboot_trigger_log.stdout"
-            fail_msg: "Expected greenboot trigger log not found, or dependency failure found"
-            success_msg: "Found expected log and no dependency failures"
+              - "'required script /etc/greenboot/check/required.d/10_failing_check.sh failed!' in result_healthcheck_upgrade_boot.stdout"
+            fail_msg: "Rollback trigger unexpectedly ran on the upgraded boot, boot index is wrong, or a dependency failure was found"
+            success_msg: "Rollback trigger did not run on upgraded boot; failing health check confirms this is the upgrade boot"
 
       always:
         - set_fact:
@@ -215,7 +225,9 @@
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
 
-    # case: check greenboot-set-rollback-trigger log at boot after fallback
+    # case: after fallback the trigger unit is not pulled in (no staged update)
+    # systemd-update-done still uses ConditionNeedsUpdate; phrasing differs by distro
+    # but both include "no trigger condition checks were met".
     - name: check greenboot-set-rollback-trigger at boot after fallback
       block:
         - name: systemd update done log should be found here
@@ -223,18 +235,19 @@
           become: yes
           register: result_systemd_update_log
 
-        - name: greenboot rollback trigger should be found here
+        - name: greenboot rollback trigger should not run after fallback
           command: journalctl -b -0 -u greenboot-set-rollback-trigger.service
           become: yes
           register: result_greenboot_trigger_log
 
         - assert:
             that:
-              - "'Update is Completed skipped, no trigger condition checks were met' in result_systemd_update_log.stdout"
-              - "'Greenboot Rollback trigger skipped, no trigger condition checks were met' in result_greenboot_trigger_log.stdout"
+              - "'no trigger condition checks were met' in result_systemd_update_log.stdout"
+              - "'-- No entries --' in result_greenboot_trigger_log.stdout"
+              - "'Rollback trigger set successfully' not in result_greenboot_trigger_log.stdout"
               - "'Dependency failed' not in result_greenboot_trigger_log.stdout"
-            fail_msg: "Expected greenboot trigger log or systemd update log not found, or dependency failure found"
-            success_msg: "Found expected log and no dependency failures"
+            fail_msg: "Expected systemd-update-done skip log, or rollback trigger unexpectedly ran after fallback"
+            success_msg: "systemd-update-done skipped and rollback trigger did not run after fallback"
 
       always:
         - set_fact:
@@ -243,39 +256,6 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
-      when:
-        - ansible_facts['distribution'] == "Fedora"
-
-    # case: check greenboot-set-rollback-trigger log at boot after fallback
-    - name: check greenboot-set-rollback-trigger at boot after fallback
-      block:
-        - name: systemd update done log should be found here
-          command: journalctl -b -0 -u systemd-update-done.service
-          become: yes
-          register: result_systemd_update_log
-
-        - name: greenboot rollback trigger should be found here
-          command: journalctl -b -0 -u greenboot-set-rollback-trigger.service
-          become: yes
-          register: result_greenboot_trigger_log
-
-        - assert:
-            that:
-              - "'Update is Completed was skipped because no trigger condition checks were met' in result_systemd_update_log.stdout"
-              - "'Greenboot Rollback trigger was skipped because no trigger condition checks were met' in result_greenboot_trigger_log.stdout"
-              - "'Dependency failed' not in result_greenboot_trigger_log.stdout"
-            fail_msg: "Expected greenboot trigger log or systemd update log not found, or dependency failure found"
-            success_msg: "Found expected log and no dependency failures"
-
-      always:
-        - set_fact:
-            total_counter: "{{ total_counter | int + 1 }}"
-      rescue:
-        - name: failed count + 1
-          set_fact:
-            failed_counter: "{{ failed_counter | int + 1 }}"
-      when:
-        - (ansible_facts['distribution'] == 'CentOS') or (ansible_facts['distribution'] == 'RedHat')
 
     # case: check disable health checks
     - name: check disable health checks

--- a/tests/greenboot-fedora-iot-raw.sh
+++ b/tests/greenboot-fedora-iot-raw.sh
@@ -326,8 +326,22 @@ fi
 GREENBOOT_COPR_REPO_ID="copr:copr.fedorainfracloud.org:packit:fedora-iot-greenboot-rs-${PR_NUMBER}"
 
 greenprint "📦 Downloading greenboot RPMs from Copr"
-ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "${SSH_USER}@${GUEST_ADDRESS}" \
-    "dnf download --from-repo='${GREENBOOT_COPR_REPO_ID}' --destdir /tmp/greenboot-rpms greenboot greenboot-default-health-checks"
+download_result=1
+for _ in $(seq 0 30); do
+    if ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "${SSH_USER}@${GUEST_ADDRESS}" \
+        "mkdir -p /tmp/greenboot-rpms && dnf download --disablerepo='*' --enablerepo='${GREENBOOT_COPR_REPO_ID}' --destdir /tmp/greenboot-rpms greenboot greenboot-default-health-checks"; then
+        download_result=0
+        break
+    fi
+    greenprint "Copr metadata not ready yet, retrying download in 30 seconds..."
+    sleep 30
+done
+
+if [[ $download_result != 0 ]]; then
+    greenprint "❌ Failed to download greenboot RPMs from Copr after retries"
+    clean_up
+    exit 1
+fi
 
 greenprint "📦 Replacing greenboot packages with PR build"
 ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "${SSH_USER}@${GUEST_ADDRESS}" \

--- a/tests/greenboot-ostree.sh
+++ b/tests/greenboot-ostree.sh
@@ -261,10 +261,18 @@ else
 fi
 
 greenprint "Looking up exact greenboot NEVR to pin from ${GREENBOOT_NEVR_LOOKUP_URL}"
-GREENBOOT_NEVR=$(sudo dnf repoquery \
-    --repofrompath="greenboot-nevr-lookup,${GREENBOOT_NEVR_LOOKUP_URL}" \
-    --disablerepo='*' --enablerepo=greenboot-nevr-lookup \
-    --quiet --qf '%{version}-%{release}' --latest-limit=1 greenboot)
+GREENBOOT_NEVR=""
+for _ in $(seq 0 30); do
+    GREENBOOT_NEVR=$(sudo dnf repoquery \
+        --repofrompath="greenboot-nevr-lookup,${GREENBOOT_NEVR_LOOKUP_URL}" \
+        --disablerepo='*' --enablerepo=greenboot-nevr-lookup \
+        --quiet --qf '%{version}-%{release}' --latest-limit=1 greenboot || true)
+    if [ -n "$GREENBOOT_NEVR" ]; then
+        break
+    fi
+    greenprint "Copr metadata not ready yet, retrying NEVR lookup in 30s..."
+    sleep 30
+done
 
 if [ -z "$GREENBOOT_NEVR" ]; then
     echo "Failed to resolve greenboot version-release from repo ${GREENBOOT_NEVR_LOOKUP_URL}"

--- a/tests/greenboot-ostree.sh
+++ b/tests/greenboot-ostree.sh
@@ -645,8 +645,8 @@ greenprint "🛃 Copying binary and script files to edge vm"
 ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "${SSH_USER}@${GUEST_ADDRESS}" "sudo mkdir -p /etc/greenboot/red.d /etc/greenboot/green.d"
 
 # Copy all files to temp directory first (all at once)
-scp "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" ../testing_assets/failing_binary "${SSH_USER}@${GUEST_ADDRESS}":/tmp/ && \
-scp "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" ../testing_assets/passing_binary "${SSH_USER}@${GUEST_ADDRESS}":/tmp/ && \
+scp "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "../testing_assets/failing_binary.${ARCH}" "${SSH_USER}@${GUEST_ADDRESS}":/tmp/failing_binary && \
+scp "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "../testing_assets/passing_binary.${ARCH}" "${SSH_USER}@${GUEST_ADDRESS}":/tmp/passing_binary && \
 scp "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" ../testing_assets/failing_script.sh "${SSH_USER}@${GUEST_ADDRESS}":/tmp/ && \
 scp "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" ../testing_assets/passing_script.sh "${SSH_USER}@${GUEST_ADDRESS}":/tmp/
 


### PR DESCRIPTION
## Summary

- Update `tests/greenboot-bootc.yaml` to match the current `greenboot-set-rollback-trigger.service` behavior: the unit runs via `ExecStop` when `ostree-finalize-staged` stops during reboot after `bootc upgrade`, not at boot with `ConditionNeedsUpdate`.
- Keep the success assertion on `-b -7`, where the trigger is set during the pre-upgrade shutdown.
- Rewrite the `-b -6` check to verify the trigger does **not** run on the first boot of the upgraded (failing) image, and that the failing health check ran on that boot.
- Rewrite the post-fallback `-b -0` check to expect no trigger journal entries instead of the obsolete systemd skip message; keep the `systemd-update-done` skip assertion with distro-neutral wording.
- Merge the separate Fedora and RHEL fallback blocks into a single assertion.
- Default `PR_NUM` to `0` in `greenboot-bootc-anaconda-iso.sh` and `greenboot-bootc-qcow2.sh` when `PR_NUMBER` is unset (`PR_NUM="${PR_NUMBER:-0}"`), so local test runs do not fail on an undeclared variable (workaround suggested-by @pcdubs).

### CI: Copr and DNF fixes

Follow-up fixes for PR pipeline failures unrelated to the playbook assertion changes:

- **RHEL bootc (DNF4):** Replaced `dnf download --from-repo` with `--disablerepo='*' --enablerepo='<copr-repo-id>'` in the bootc anaconda-iso and qcow2 container builds. `--from-repo` is DNF5-only and caused immediate failures on RHEL 10.3 bootc images.
- **Copr metadata race:** Added retry loops (up to ~15 minutes) for `dnf repoquery` in `greenboot-ostree.sh` and `dnf download` in `greenboot-fedora-iot-raw.sh`, so tests wait for Packit/Copr to publish `repomd.xml` before pinning or downloading greenboot RPMs.
- **Fedora 45:** Added `fedora-45-x86_64` and `fedora-45-aarch64` to `.packit.yaml` `copr_build` targets so PR builds are published for F45 IoT test chroots.

### aarch64: arch-specific test binaries

Bootc (anaconda-iso, qcow2) and ostree integration tests previously copied unsuffixed `testing_assets/passing_binary` / `failing_binary`, which are x86-64 ELFs. On aarch64 guests this produced `Exec format error` on the required health-check binary and caused a cascade of playbook failures (healthcheck never active, wrong boot journal offsets, missing `FALLBACK BOOT DETECTED!`, etc.). Scripts now select `passing_binary.${ARCH}` and `failing_binary.${ARCH}`, consistent with `greenboot-fedora-iot-raw.sh`.

## Motivation

`greenboot-bootc-anaconda-iso` was failing on RHEL 10.3 even though greenboot rollback worked correctly. The two failing assertions still expected the old boot-time `ConditionNeedsUpdate` trigger behavior.

Assisted-by: Cursor (composer-2.5)